### PR TITLE
Issue 89: Simplify `fit_seromodel()` output

### DIFF
--- a/R/model_comparison.R
+++ b/R/model_comparison.R
@@ -11,16 +11,17 @@
 #' model_constant <- run_seromodel(serodata = data_test, 
 #'                                 foi_model = "constant", 
 #'                                 n_iters = 1500)
-#' get_table_rhats(model_object = model_constant)
+#' get_table_rhats(model_constant, data_test)
 #' }
 #' @export
-get_table_rhats <- function(seromodel_object) {
-  rhats <- bayesplot::rhat(seromodel_object$fit, "foi")
-
+get_table_rhats <- function(seromodel_object,
+                            serodata) {
+  rhats <- bayesplot::rhat(seromodel_object, "foi")
+  exposure_years <- (min(serodata$birth_year):serodata$tsur[1])[-1]
   if (any(is.nan(rhats))) {
     rhats[which(is.nan(rhats))] <- 0
   }
-  model_rhats <- data.frame(year = seromodel_object$exposure_years, rhat = rhats)
+  model_rhats <- data.frame(year = exposure_years, rhat = rhats)
   model_rhats$rhat[model_rhats$rhat == 0] <- NA
 
   return(model_rhats)

--- a/R/modelling.R
+++ b/R/modelling.R
@@ -45,7 +45,7 @@
 #' \dontrun{
 #' serodata <- prepare_serodata(serodata)
 #' run_seromodel (serodata,
-#'            foi_model = "constant")
+#'                foi_model = "constant")
 #' }
 #' @export
 run_seromodel <- function(serodata,
@@ -196,7 +196,6 @@ fit_seromodel <- function(serodata,
 
       medianv = apply(foi, 2, function(x) quantile(x, medianv_quantile))
     )
-
     # generates a sample of iterations
     if (n_iters >= 2000) {
       foi_post_s <- dplyr::sample_n(as.data.frame(foi), size = 1000)
@@ -207,7 +206,6 @@ fit_seromodel <- function(serodata,
     }
 
     return(fit)
-
   } else {
 
     return("no model")
@@ -235,7 +233,9 @@ get_exposure_ages <- function(serodata) {
 # TODO Is necessary to explain better what we mean by the exposure matrix.
 #' Function that generates the exposure matrix corresponding to a serological survey
 #'
-#' @param serodata A data frame containing the data from a seroprevalence survey. This data frame must contain the year of birth for each individual (birth_year) and the time of the survey (tsur). birth_year can be constructed by means of the \link{prepare_serodata} function.
+#' @param serodata A data frame containing the data from a seroprevalence survey.
+#' This data frame must contain the year of birth for each individual (birth_year) and the time of the survey (tsur).
+#' birth_year can be constructed by means of the \link{prepare_serodata} function.
 #' @return \code{exposure_output}. An atomic matrix containing the expositions for each entry of \code{serodata} by year.
 #' @examples
 #' \dontrun{
@@ -264,6 +264,7 @@ get_exposure_matrix <- function(serodata) {
 #' corresponding standar deviation.
 #' @param seromodel_object \code{seromodel_object}. An object containing relevant information about the implementation of the model.
 #' Refer to \link{fit_seromodel} for further details.
+#' @param serodata A data frame containing the data from a seroprevalence survey.
 #' @return \code{model_summary}. Object with a summary of \code{seromodel_object} containing the following:
 #' \tabular{ll}{
 #' \code{foi_model} \tab Name of the selected model. \cr \tab \cr

--- a/R/visualisation.R
+++ b/R/visualisation.R
@@ -63,10 +63,10 @@ plot_seroprev <- function(serodata,
 plot_seroprev_fitted <- function(seromodel_object,
                                  size_text = 6) {
 
-  if (is.character(seromodel_object$fit) == FALSE)  {
+  if (is.character(seromodel_object) == FALSE)  {
     if  (class(seromodel_object$fit@sim$samples)  != "NULL" ) {
 
-      foi <- rstan::extract(seromodel_object$fit, "foi", inc_warmup = FALSE)[[1]]
+      foi <- rstan::extract(seromodel_object, "foi", inc_warmup = FALSE)[[1]]
       prev_expanded <- get_prev_expanded(foi, serodata = seromodel_object$serodata, bin_data = TRUE)
       prev_plot <-
         ggplot2::ggplot(prev_expanded) +
@@ -146,9 +146,9 @@ plot_foi <- function(seromodel_object,
                      max_lambda = NA,
                      size_text = 25,
                      foi_sim = NULL) {
-  if (is.character(seromodel_object$fit) == FALSE) {
-    if (class(seromodel_object$fit@sim$samples) != "NULL") {
-      foi <- rstan::extract(seromodel_object$fit,
+  if (is.character(seromodel_object) == FALSE) {
+    if (class(seromodel_object@sim$samples) != "NULL") {
+      foi <- rstan::extract(seromodel_object,
                             "foi",
                             inc_warmup = FALSE)[[1]]
 
@@ -241,9 +241,9 @@ plot_foi <- function(seromodel_object,
 #' @export
 plot_rhats <- function(seromodel_object,
                        size_text = 25) {
-  if (is.character(seromodel_object$fit) == FALSE) {
-    if (class(seromodel_object$fit@sim$samples) != "NULL") {
-      rhats <- get_table_rhats(seromodel_object)
+  if (is.character(seromodel_object) == FALSE) {
+    if (class(seromodel_object@sim$samples) != "NULL") {
+      rhats <- get_table_rhats(seromodel_object, serodata)
 
       rhats_plot <-
         ggplot2::ggplot(rhats, ggplot2::aes(year, rhat)) +
@@ -307,8 +307,8 @@ plot_seromodel <- function(seromodel_object,
                           max_lambda = NA,
                           size_text = 25,
                           foi_sim = NULL) {
-  if (is.character(seromodel_object$fit) == FALSE) {
-    if (class(seromodel_object$fit@sim$samples) != "NULL") {
+  if (is.character(seromodel_object) == FALSE) {
+    if (class(seromodel_object@sim$samples) != "NULL") {
       prev_plot <- plot_seroprev_fitted(seromodel_object = seromodel_object,
                                  size_text = size_text)
 

--- a/man/extract_seromodel_summary.Rd
+++ b/man/extract_seromodel_summary.Rd
@@ -4,11 +4,13 @@
 \alias{extract_seromodel_summary}
 \title{Method to extact a summary of the specified serological model object}
 \usage{
-extract_seromodel_summary(seromodel_object)
+extract_seromodel_summary(seromodel_object, serodata)
 }
 \arguments{
 \item{seromodel_object}{\code{seromodel_object}. An object containing relevant information about the implementation of the model.
 Refer to \link{fit_seromodel} for further details.}
+
+\item{serodata}{A data frame containing the data from a seroprevalence survey.}
 }
 \value{
 \code{model_summary}. Object with a summary of \code{seromodel_object} containing the following:
@@ -39,6 +41,7 @@ data("serodata")
 serodata <- prepare_serodata(serodata)
 seromodel_object <- run_seromodel(serodata = serodata,
                                   foi_model = "constant")
-extract_seromodel_summary(seromodel_object)
+extract_seromodel_summary(seromodel_object,
+                          serodata)
 }
 }

--- a/man/get_exposure_matrix.Rd
+++ b/man/get_exposure_matrix.Rd
@@ -7,7 +7,9 @@
 get_exposure_matrix(serodata)
 }
 \arguments{
-\item{serodata}{A data frame containing the data from a seroprevalence survey. This data frame must contain the year of birth for each individual (birth_year) and the time of the survey (tsur). birth_year can be constructed by means of the \link{prepare_serodata} function.}
+\item{serodata}{A data frame containing the data from a seroprevalence survey.
+This data frame must contain the year of birth for each individual (birth_year) and the time of the survey (tsur).
+birth_year can be constructed by means of the \link{prepare_serodata} function.}
 }
 \value{
 \code{exposure_output}. An atomic matrix containing the expositions for each entry of \code{serodata} by year.

--- a/man/get_table_rhats.Rd
+++ b/man/get_table_rhats.Rd
@@ -4,7 +4,7 @@
 \alias{get_table_rhats}
 \title{Method for extracting a dataframe containing the R-hat estimates for a given serological model}
 \usage{
-get_table_rhats(seromodel_object)
+get_table_rhats(seromodel_object, serodata)
 }
 \arguments{
 \item{seromodel_object}{seromodel_object}
@@ -23,6 +23,6 @@ data_test <- prepare_serodata(serodata = serodata)
 model_constant <- run_seromodel(serodata = data_test, 
                                 foi_model = "constant", 
                                 n_iters = 1500)
-get_table_rhats(model_object = model_constant)
+get_table_rhats(model_constant, data_test)
 }
 }

--- a/man/run_seromodel.Rd
+++ b/man/run_seromodel.Rd
@@ -69,6 +69,6 @@ This function runs the specified model for the Force-of-Infection \code{foi_mode
 \dontrun{
 serodata <- prepare_serodata(serodata)
 run_seromodel (serodata,
-           foi_model = "constant")
+               foi_model = "constant")
 }
 }


### PR DESCRIPTION
This PR fixes #89 . Now the function `fit_seromodel()` returns only a `stanfit` object with the implementation of the corresponding model.

In order not to change much the usability of the package and to simplify the usage of several functions across the package, we decided to keep using a list containing at least the `stanfit` object (`seromodel_fit`) and `serodata` as the output of `run_seromodel`. In the future this function will check input types and implement other pre-processing tasks not directly related with the fitting process. This will clearly distinguish `run_seromodel` from `fit_seromodel()`, which resolves #95.

