### PR TITLE
Simplify `get_prev_expanded()`

### DIFF
--- a/R/modelling.R
+++ b/R/modelling.R
@@ -435,18 +435,14 @@ get_prev_expanded <- function(foi,
 
   prev_pn <- t(1 - exp(-exposure_expanded %*% t(foi_expanded)))
 
-  lower <- apply(prev_pn, 2, quantile, 0.1)
-
-  upper <- apply(prev_pn, 2, quantile, 0.9)
-
-  medianv <- apply(prev_pn, 2, quantile, 0.5)
-
-  predicted_prev <- data.frame(
-    age = 1:age_max,
-    predicted_prev = medianv,
-    predicted_prev_lower = lower,
-    predicted_prev_upper = upper
+  predicted_prev <- t(apply(prev_pn, 2, function(x) quantile(x, c(0.5, 0.1, 0.9))))
+  colnames(predicted_prev) <- c(
+    "predicted_prev",
+    "predicted_prev_lower",
+    "predicted_prev_upper"
   )
+  predicted_prev <- as.data.frame(predicted_prev)
+  predicted_prev$age <- 1:ly
 
   observed_prev <- serodata %>%
     dplyr::select(

--- a/R/modelling.R
+++ b/R/modelling.R
@@ -429,13 +429,9 @@ get_prev_expanded <- function(foi,
 
   foi_expanded <- foin
 
-  age_class <- seq_len(NCOL(foi_expanded))
   ly <- NCOL(foi_expanded)
-  exposure <- matrix(0, nrow = length(age_class), ncol = ly)
-  for (k in seq_along(age_class)) {
-    exposure[k, (ly - age_class[k] + 1):ly] <- 1
-  }
-  exposure_expanded <- exposure
+  exposure_expanded <- matrix(0, nrow = ly, ncol = ly)
+  exposure_expanded[lower.tri(exposure_expanded, diag = TRUE)] <- 1
 
   iterf <- NROW(foi_expanded)
   age_max <- NROW(exposure_expanded)

--- a/R/modelling.R
+++ b/R/modelling.R
@@ -433,12 +433,7 @@ get_prev_expanded <- function(foi,
   exposure_expanded <- matrix(0, nrow = ly, ncol = ly)
   exposure_expanded[lower.tri(exposure_expanded, diag = TRUE)] <- 1
 
-  iterf <- NROW(foi_expanded)
-  age_max <- NROW(exposure_expanded)
-  prev_pn <- matrix(NA, nrow = iterf, ncol = age_max)
-  for (i in 1:iterf) {
-    prev_pn[i, ] <- 1 - exp(-exposure_expanded %*% foi_expanded[i, ])
-  }
+  prev_pn <- t(1 - exp(-exposure_expanded %*% t(foi_expanded)))
 
   lower <- apply(prev_pn, 2, quantile, 0.1)
 


### PR DESCRIPTION
This function includes unnecessary loops that make it difficult to understand what's happening. I'm still not 100% sure this is the intended behaviour of this function but this PR does not change it. The result is the same as what `main` currently gives.

As always, I recommend reviewing this PR commit by commit since each commit focuses on a specific area of change.
