### PR TITLE
Replace `pracma::dot()` loop by matrix multiplication

### DIFF
--- a/.github/workflows/dependency-change.yaml
+++ b/.github/workflows/dependency-change.yaml
@@ -1,0 +1,75 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  pull_request:
+    paths:
+      - 'DESCRIPTION'
+
+name: Analyze dependency changes
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependency-changes:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: any::pak, glue, gh
+
+      - name: Analyze dependency changes
+        shell: Rscript {0}
+        run: |
+          deps_base <- pak::pkg_deps("${{ github.repository }}@${{ github.base_ref }}", dependencies = TRUE) |>
+            subset(!directpkg) |>
+            subset(is.na(priority))
+          # We install from PR number rather than branch to deal with the case
+          # of PR coming from forks
+          deps_head <- pak::pkg_deps("${{ github.repository }}#${{ github.event.number }}", dependencies = TRUE) |>
+            subset(!directpkg) |>
+            subset(is.na(priority))
+
+          deps_added <- deps_head |>
+            subset(!ref %in% deps_base$ref)
+
+          deps_removed <- deps_base |>
+            subset(!ref %in% deps_head$ref)
+
+          if (nrow(deps_added) + nrow(deps_removed) > 0) {
+
+            message("Dependencies have changed! Analyzing...")
+
+            msg <- glue::glue(
+              .sep = "\n",
+              "This pull request:",
+              "- Adds {nrow(deps_added)} new dependencies (direct and indirect)",
+              "- Adds {length(unique(deps_added$sysreqs))} new system dependencies",
+              "- Removes {nrow(deps_removed)} existing dependencies (direct and indirect)",
+              "- Removes {length(unique(deps_removed$sysreqs))} existing system dependencies",
+              "",
+              "(Note that results may be inacurrate if you branched from an outdated version of the target branch.)"
+            )
+
+            message("Posting results as a pull request comment.")
+
+            gh::gh(
+              "POST /repos/{repo}/issues/{issue_number}/comments",
+              repo = "${{ github.repository }}",
+              issue_number = "${{ github.event.number }}",
+              body = msg
+            )
+
+          }

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,8 +52,7 @@ Imports:
     ggplot2,
     Hmisc,
     loo,
-    purrr,
-    pracma
+    purrr
 LinkingTo: 
     BH (>= 1.66.0),
     Rcpp (>= 0.12.0),

--- a/R/seroprevalence_data.R
+++ b/R/seroprevalence_data.R
@@ -170,10 +170,7 @@ get_sim_probability <- function(sim_data, foi) {
   cohort_ages <- get_cohort_ages(sim_data)
   exposure_ages <- rev(cohort_ages$age)
   exposure_matrix <- get_exposure_matrix(sim_data) # nolint: object_usage_linter
-  probabilities <- purrr::map_dbl(
-    exposure_ages,
-    ~ 1 - exp(-pracma::dot(exposure_matrix[., ], foi))
-  )
+  probabilities <- 1 - exp(-drop(exposure_matrix %*% foi))
 
   sim_probability <- data.frame(
     age = exposure_ages,

--- a/tests/testthat/test_get_sim.R
+++ b/tests/testthat/test_get_sim.R
@@ -29,7 +29,7 @@ test_that("test get_sim functionalities", {
 
   exposure_matrix <- matrix(1, n_years, n_years)
   exposure_matrix[lower.tri(exposure_matrix)] <- 0
-  probabilities <- purrr::map_dbl(1:n_years, ~ 1 - exp(-pracma::dot(exposure_matrix[., ], foi_sim)))
+  probabilities <- 1 - exp(-drop(exposure_matrix %*% foi_sim))
 
   expect_s3_class(sim_probability, "data.frame")
   expect_type(sim_probability$age, "integer")


### PR DESCRIPTION
This removes an external dependency and makes the code more performant.

Benchmark:

``` r
library(serofoi)

foi <- rep(0.02, 50)
sim_data <- generate_sim_data(
  foi = foi,
  sample_size_by_age = 5,
  tsur = 2050,
  birth_year_min = 2000,
  survey_label = "foi_sim"
)

cohort_ages <- get_cohort_ages(sim_data)
exposure_ages <- rev(cohort_ages$age)
exposure_matrix <- serofoi:::get_exposure_matrix(sim_data) # nolint: object_usage_linter

microbenchmark::microbenchmark({
  purrr::map_dbl(
    exposure_ages,
    ~ 1 - exp(-pracma::dot(exposure_matrix[., ], foi))
  )
}, {
  1 - exp(-drop(exposure_matrix[, ] %*% foi))
})
#> Unit: microseconds
#>                                                                                               expr
#>  {     purrr::map_dbl(exposure_ages, ~1 - exp(-pracma::dot(exposure_matrix[.,          ], foi))) }
#>                                                {     1 - exp(-drop(exposure_matrix %*% foi)) }
#>      min       lq       mean    median       uq      max neval
#>  855.887 1231.358 1612.88416 1434.9305 1850.731 6478.254   100
#>    5.982   13.144   22.63188   17.5525   24.318  185.766   100
```

<sup>Created on 2024-01-09 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

From a theoretical point of view and from my testing, it should be functionally equivalent to the previous version but please double check.