### PR TITLE
fix(bug): correct exposure_expanded matrix calculation avoiding loops

### DIFF
--- a/R/modelling.R
+++ b/R/modelling.R
@@ -431,7 +431,10 @@ get_prev_expanded <- function(foi,
 
   ly <- NCOL(foi_expanded)
   exposure_expanded <- matrix(0, nrow = ly, ncol = ly)
-  exposure_expanded[lower.tri(exposure_expanded, diag = TRUE)] <- 1
+  exposure_expanded[apply(
+    lower.tri(exposure_expanded, diag = TRUE),
+    1, rev
+    )] <- 1
 
   prev_pn <- t(1 - exp(-exposure_expanded %*% t(foi_expanded)))
 

--- a/R/modelling.R
+++ b/R/modelling.R
@@ -328,7 +328,7 @@ get_foi_central_estimates <- function(seromodel_object,
 #'   \item{`antibody`}{Antibody}
 #'   \item{`n_sample`}{Total number of samples in the survey.}
 #'   \item{`n_agec`}{Number of age groups considered.}
-#'   \item{`n_iter`}{Number of nteractions for each chain including warmup.}
+#'   \item{`n_iter`}{Number of interactions for each chain including warmup.}
 #'   \item{`elpd`}{elpd}
 #'   \item{`se`}{se}
 #'   \item{`converged`}{convergence}

--- a/R/modelling.R
+++ b/R/modelling.R
@@ -328,7 +328,7 @@ get_foi_central_estimates <- function(seromodel_object,
 #'   \item{`antibody`}{Antibody}
 #'   \item{`n_sample`}{Total number of samples in the survey.}
 #'   \item{`n_agec`}{Number of age groups considered.}
-#'   \item{`n_iter`}{Number of interactions for each chain including the warmup.}
+#'   \item{`n_iter`}{Number of nteractions for each chain including warmup.}
 #'   \item{`elpd`}{elpd}
 #'   \item{`se`}{se}
 #'   \item{`converged`}{convergence}
@@ -435,7 +435,12 @@ get_prev_expanded <- function(foi,
 
   prev_pn <- t(1 - exp(-exposure_expanded %*% t(foi_expanded)))
 
-  predicted_prev <- t(apply(prev_pn, 2, function(x) quantile(x, c(0.5, 0.1, 0.9))))
+  predicted_prev <- t(
+    apply(
+      prev_pn, 2,
+      function(x) quantile(x, c(0.5, 0.1, 0.9))
+      )
+    )
   colnames(predicted_prev) <- c(
     "predicted_prev",
     "predicted_prev_lower",

--- a/R/seroprevalence_data.R
+++ b/R/seroprevalence_data.R
@@ -44,15 +44,19 @@ prepare_serodata <- function(serodata = serodata,
   stopifnot(
     "serodata must contain the right columns" =
       all(c(
-        "survey", "total", "counts", "age_min", "age_max", "tsur",
-        "country", "test", "antibody"
+        "survey", "total", "counts", "tsur"
       ) %in%
+      # serodata should contain either age_min and age_max,
+      # or age_mean_f to fully identify the age groups
+        colnames(serodata)) & (
+        any(c(
+          "age_min", "age_max"
+          ) %in%
         colnames(serodata)) |
-        all(c(
-          "survey", "total", "counts", "age_mean_f", "tsur",
-          "country", "test", "antibody"
-        ) %in%
+        any(
+          "age_mean_f" %in%
           colnames(serodata))
+      )
   )
   if (!any(colnames(serodata) == "age_mean_f")) {
     serodata <- serodata %>%

--- a/R/seroprevalence_data.R
+++ b/R/seroprevalence_data.R
@@ -77,6 +77,38 @@ prepare_serodata <- function(serodata = serodata,
         ) %in% colnames(serodata)) |
         "age_mean_f" %in% colnames(serodata)
   )
+
+  if (!any(colnames(serodata) == "country")) {
+    warning(
+      paste0(
+        "Column 'country' is missing. ",
+        "Consider adding it as additional information."
+      )
+    )
+    serodata$country <- "None"
+  }
+
+
+  if (!any(colnames(serodata) == "test")) {
+    warning(
+      paste0(
+        "Column 'test' is missing. ",
+        "Consider adding it as additional information."
+      )
+    )
+    serodata$test <- "None"
+  }
+
+  if (!any(colnames(serodata) == "antibody")) {
+    warning(
+      paste0(
+        "Column 'antibody' is missing. ",
+        "Consider adding it as additional information."
+      )
+    )
+    serodata$antibody <- "None"
+  }
+
   if (!any(colnames(serodata) == "age_mean_f")) {
     serodata <- serodata %>%
       dplyr::mutate(

--- a/R/seroprevalence_data.R
+++ b/R/seroprevalence_data.R
@@ -309,7 +309,7 @@ get_sim_n_seropositive <- function(
 #' @param antibody Type of antibody detected by the serosurvey
 #' @param test Type of test taken
 #' @param seed The seed for random number generation.
-#' @return Dataframe object containing the simulated data generated from \code{foi}
+#' @return Dataframe object containing the simulated data
 #' @examples
 #' \dontrun{
 #' sample_size_by_age <- 5
@@ -331,15 +331,20 @@ generate_sim_data <- function(foi,
                               test = "fake",
                               antibody = "IgG",
                               seed = 1234
-                              ){
+                              ) {
     sim_data <- data.frame(birth_year = c(birth_year_min:(tsur - 1))) %>%
         mutate(tsur = tsur,
-            country = 'None',
+            country = "None",
             test = test,
             antibody = antibody,
             survey = survey_label,
             age_mean_f = tsur - .data$birth_year)
-    sim_n_seropositive <- get_sim_n_seropositive(sim_data, foi, sample_size_by_age, seed = seed)
+    sim_n_seropositive <- get_sim_n_seropositive(
+      sim_data = sim_data,
+      foi = foi,
+      sample_size_by_age = sample_size_by_age,
+      seed = seed
+      )
     sim_data <- sim_data %>%
         mutate(counts = sim_n_seropositive$n_seropositive,
                total = sample_size_by_age) %>%

--- a/R/seroprevalence_data.R
+++ b/R/seroprevalence_data.R
@@ -47,7 +47,7 @@ prepare_serodata <- function(serodata = serodata,
   checkmate::assert_numeric(alpha, lower = 0, upper = 1)
   # Check that serodata has the right columns
   cols_check <- c("survey", "total", "counts", "tsur")
-  if(
+  if (
     !all(
       cols_check
       %in% colnames(serodata)
@@ -56,9 +56,8 @@ prepare_serodata <- function(serodata = serodata,
       stop(
         "serodata must contain the right columns. ",
         sprintf(
-          "Column(s) (%s) are missing.", paste0(
-            cols_check[which(!(cols_check %in% colnames(serodata)))],
-            collapse = ", "
+          "Column(s) (%s) are missing.", toString(
+            cols_check[which(!(cols_check %in% colnames(serodata)))]
           )
         )
       )
@@ -66,12 +65,9 @@ prepare_serodata <- function(serodata = serodata,
 
   # Check that the serodata has the necessary columns to fully
   # identify the age groups
-  err_message <- message(
-      "serodata must contain both 'age_min' and 'age_max, ",
-      "or 'age_mean_f' to fully identify the age groups"
-    )
   stopifnot(
-    err_message =
+    "serodata must contain both 'age_min' and 'age_max',
+    or 'age_mean_f' to fully identify the age groups" =
       all(c(
         "age_min", "age_max"
         ) %in% colnames(serodata)) |
@@ -80,10 +76,8 @@ prepare_serodata <- function(serodata = serodata,
 
   if (!any(colnames(serodata) == "country")) {
     warning(
-      paste0(
         "Column 'country' is missing. ",
         "Consider adding it as additional information."
-      )
     )
     serodata$country <- "None"
   }
@@ -91,20 +85,16 @@ prepare_serodata <- function(serodata = serodata,
 
   if (!any(colnames(serodata) == "test")) {
     warning(
-      paste0(
         "Column 'test' is missing. ",
         "Consider adding it as additional information."
-      )
     )
     serodata$test <- "None"
   }
 
   if (!any(colnames(serodata) == "antibody")) {
     warning(
-      paste0(
         "Column 'antibody' is missing. ",
         "Consider adding it as additional information."
-      )
     )
     serodata$antibody <- "None"
   }

--- a/man/extract_seromodel_summary.Rd
+++ b/man/extract_seromodel_summary.Rd
@@ -47,7 +47,7 @@ containing the following:
 \item{\code{antibody}}{Antibody}
 \item{\code{n_sample}}{Total number of samples in the survey.}
 \item{\code{n_agec}}{Number of age groups considered.}
-\item{\code{n_iter}}{Number of interactions for each chain including the warmup.}
+\item{\code{n_iter}}{Number of nteractions for each chain including warmup.}
 \item{\code{elpd}}{elpd}
 \item{\code{se}}{se}
 \item{\code{converged}}{convergence}

--- a/man/extract_seromodel_summary.Rd
+++ b/man/extract_seromodel_summary.Rd
@@ -47,7 +47,7 @@ containing the following:
 \item{\code{antibody}}{Antibody}
 \item{\code{n_sample}}{Total number of samples in the survey.}
 \item{\code{n_agec}}{Number of age groups considered.}
-\item{\code{n_iter}}{Number of nteractions for each chain including warmup.}
+\item{\code{n_iter}}{Number of interactions for each chain including warmup.}
 \item{\code{elpd}}{elpd}
 \item{\code{se}}{se}
 \item{\code{converged}}{convergence}

--- a/man/generate_sim_data.Rd
+++ b/man/generate_sim_data.Rd
@@ -36,7 +36,7 @@ the number of trials \code{size} in \link[stats:Binomial]{rbinom}.}
 \item{seed}{The seed for random number generation.}
 }
 \value{
-Dataframe object containing the simulated data generated from \code{foi}
+Dataframe object containing the simulated data
 }
 \description{
 Function that generates a simulated serosurvey according to the specified FoI

--- a/man/plot_seroprev.Rd
+++ b/man/plot_seroprev.Rd
@@ -20,7 +20,11 @@ This data frame must contain the following columns:
 \item{\code{country}}{The country where the survey took place}
 \item{\code{test}}{The type of test taken}
 \item{\code{antibody}}{antibody}
-}}
+}
+Alternatively to \code{age_min} and \code{age_max}, the dataset could already include
+the age group marker \code{age_mean_f}, representing the middle point between
+\code{age_min} and \code{age_max}. If \code{afe_mean_f} is missing, it will be generated
+by the function.}
 
 \item{size_text}{Text size use in the theme of the graph returned by the
 function.}

--- a/man/prepare_serodata.Rd
+++ b/man/prepare_serodata.Rd
@@ -19,7 +19,11 @@ This data frame must contain the following columns:
 \item{\code{country}}{The country where the survey took place}
 \item{\code{test}}{The type of test taken}
 \item{\code{antibody}}{antibody}
-}}
+}
+Alternatively to \code{age_min} and \code{age_max}, the dataset could already include
+the age group marker \code{age_mean_f}, representing the middle point between
+\code{age_min} and \code{age_max}. If \code{afe_mean_f} is missing, it will be generated
+by the function.}
 
 \item{alpha}{probability of a type I error. For further details refer to
 \link[Hmisc:binconf]{binconf}.}
@@ -28,7 +32,8 @@ This data frame must contain the following columns:
 serodata with additional columns necessary for the analysis. These
 columns are:
 \describe{
-\item{\code{age_mean_f}}{Floor value of the average between age_min and age_max}
+\item{\code{age_mean_f}}{Floor value of the average between age_min and age_max
+for the age groups delimited by \code{age_min} and \code{age_max}}
 \item{\code{sample_size}}{The size of the sample}
 \item{\code{birth_year}}{Years in which the subject was born according to the
 age group marker \code{age_mean_f}}


### PR DESCRIPTION
This PR fixes the bug described in #145 . The right exposure triangular matrix with respect to the anti-diagonal is computed avoiding `for` loops by:
```
ly <- NCOL(foi_expanded)
exposure_expanded <- matrix(0, nrow = ly, ncol = ly)
exposure_expanded[apply(
  lower.tri(exposure_expanded, diag = TRUE),
  1, rev
  )] <- 1
```
