### PR TITLE
Refac visualisation module

### DIFF
--- a/R/modelling.R
+++ b/R/modelling.R
@@ -243,7 +243,8 @@ fit_seromodel <- function(
   # Validate arguments
   validate_prepared_serodata(serodata)
   stopifnot(
-    "foi_model must be either `constant`, `tv_normal_log`, or `tv_normal`" = foi_model %in% c("constant", "tv_normal_log", "tv_normal"),
+    "foi_model must be either `constant`, `tv_normal_log`, or `tv_normal`" =
+      foi_model %in% c("constant", "tv_normal_log", "tv_normal"),
     "iter must be numeric" = is.numeric(iter),
     "thin must be numeric" = is.numeric(thin),
     "adapt_delta must be numeric" = is.numeric(adapt_delta),

--- a/R/modelling.R
+++ b/R/modelling.R
@@ -482,8 +482,6 @@ extract_seromodel_summary <- function(seromodel_object,
   return(model_summary)
 }
 
-# TODO Complete @param documentation
-
 #' Function that generates an object containing the confidence interval based on
 #' a Force-of-Infection fitting
 #'
@@ -493,13 +491,15 @@ extract_seromodel_summary <- function(seromodel_object,
 #' @param foi Object containing the information of the force of infection. It is
 #'   obtained from `rstan::extract(seromodel_object$seromodel, "foi", inc_warmup
 #'   = FALSE)[[1]]`.
+#' @param alpha Probability threshold for statistical significance used for both
+#' the binomial confidence interval, and the lower and upper quantiles of the
+#' estimated prevalence.
 #' @inheritParams run_seromodel
-#' @param bin_data If `TRUE`, `serodata` is binned by means of
-#'   `prepare_bin_data`. Otherwise, age groups are kept as originally input.
-#' @param predicted_prev_lower_quantile Float specifying the lower quantile
-#'   to be used in `predicted_prev` calculation
-#' @param predicted_prev_upper_quantile Float specifying the upper quantile
-#'   to be used in `predicted_prev` calculation
+#' @param bin_data Boolean. Use `TRUE` when age binning is preferred for
+#' plotting. If `TRUE`, `serodata` is binned by means of
+#' `prepare_bin_data`; Otherwise, age groups are kept as originally input.
+#' @param bin_step Integer specifying the age groups bin size to be used when
+#' `bin_data` is set to `TRUE`.
 #' @return `prev_final`. The expanded prevalence data. This is used for plotting
 #'   purposes in the `visualization` module.
 #' @examples

--- a/R/visualisation.R
+++ b/R/visualisation.R
@@ -36,12 +36,17 @@ plot_seroprev <- function(serodata,
       serodata,
       bin_step = bin_step
       )
+    min_prev <- min(serodata_bin$prev_obs_lower)
+    max_prev <- max(serodata_bin$prev_obs_upper)
 
     seroprev_plot <- ggplot2::ggplot(
       data = serodata_bin,
       ggplot2::aes(x = .data$age_mean_f)
       )
     } else {
+    min_prev <- min(serodata$prev_obs_lower)
+    max_prev <- max(serodata$prev_obs_upper)
+    
     seroprev_plot <- ggplot2::ggplot(
       data = serodata,
       ggplot2::aes(x = .data$age_mean_f)
@@ -64,7 +69,7 @@ plot_seroprev <- function(serodata,
   ) +
     ggplot2::coord_cartesian(
       xlim = c(min(serodata$age_min), max(serodata$age_max)),
-      ylim = c(min(serodata$prev_obs_lower), max(serodata$prev_obs_upper))
+      ylim = c(min_prev, max_prev)
       ) +
     ggplot2::theme_bw(size_text)  +
     ggplot2::theme(legend.position = "none") +

--- a/R/visualisation.R
+++ b/R/visualisation.R
@@ -32,40 +32,32 @@ plot_seroprev <- function(serodata,
     }
 
   if (bin_data) {
-    serodata_bin <- prepare_bin_data(
+    serodata <- prepare_bin_data(
       serodata,
       bin_step = bin_step
       )
-    min_prev <- min(serodata_bin$prev_obs_lower)
-    max_prev <- max(serodata_bin$prev_obs_upper)
+    }
 
-    seroprev_plot <- ggplot2::ggplot(
-      data = serodata_bin,
-      ggplot2::aes(x = .data$age_mean_f)
-      )
-    } else {
-    min_prev <- min(serodata$prev_obs_lower)
-    max_prev <- max(serodata$prev_obs_upper)
-    
-    seroprev_plot <- ggplot2::ggplot(
-      data = serodata,
-      ggplot2::aes(x = .data$age_mean_f)
-    )
-  }
-   seroprev_plot <- seroprev_plot +
-    ggplot2::geom_errorbar(
-    ggplot2::aes(
-      ymin = .data$prev_obs_lower,
-      ymax = .data$prev_obs_upper
-      ),
-    width = 0.1
+  min_prev <- min(serodata$prev_obs_lower)
+  max_prev <- max(serodata$prev_obs_upper)
+
+  seroprev_plot <- ggplot2::ggplot(
+    data = serodata,
+    ggplot2::aes(x = .data$age_mean_f)
   ) +
-  ggplot2::geom_point(
-    ggplot2::aes(
-      y = .data$prev_obs,
-      size = .data$total
-      ),
-    fill = "#7a0177", colour = "black", shape = 21
+    ggplot2::geom_errorbar(
+      ggplot2::aes(
+        ymin = .data$prev_obs_lower,
+        ymax = .data$prev_obs_upper
+        ),
+        width = 0.1
+      ) +
+    ggplot2::geom_point(
+      ggplot2::aes(
+        y = .data$prev_obs,
+        size = .data$total
+        ),
+      fill = "#7a0177", colour = "black", shape = 21
   ) +
     ggplot2::coord_cartesian(
       xlim = c(min(serodata$age_min), max(serodata$age_max)),

--- a/R/visualisation.R
+++ b/R/visualisation.R
@@ -192,86 +192,62 @@ plot_foi <- function(seromodel_object,
                      max_lambda = NA,
                      size_text = 25,
                      foi_sim = NULL) {
-  if (is.character(seromodel_object)) {
-    message("model did not run")
-    print_warning <- "errors"
+  checkmate::assert_class(seromodel_object, "stanfit", null.ok = TRUE)
+  #-------- This bit is to get the actual length of the foi data
+  foi_data <- get_foi_central_estimates(
+    seromodel_object = seromodel_object,
+    cohort_ages = cohort_ages
+  )
 
-    foi_plot <- ggplot2::ggplot(data.frame()) +
-      ggplot2::geom_point() +
-      ggplot2::xlim(0, 10) +
-      ggplot2::ylim(0, 10) +
-      ggplot2::annotate("text",
-                        x = 4,
-                        y = 5,
-                        label = print_warning
-      ) +
-      ggplot2::theme_bw(25) +
-      ggplot2::theme(
-        axis.text.x = ggplot2::element_blank(),
-        axis.text.y = ggplot2::element_blank()
-      ) +
-      ggplot2::ylab(" ") +
-      ggplot2::xlab(" ")
-    ggplot2::theme(plot.title = ggplot2::element_text(size = 10))
-  } else {
-    if (!is.null(seromodel_object@sim$samples)) {
-      #-------- This bit is to get the actual length of the foi data
-      foi_data <- get_foi_central_estimates(
-        seromodel_object = seromodel_object,
-        cohort_ages = cohort_ages
+  foi_plot <-
+    ggplot2::ggplot(foi_data, ggplot2::aes(x = .data$year)) +
+    ggplot2::geom_ribbon(
+      ggplot2::aes(
+        ymin = .data$lower,
+        ymax = .data$upper
+      ),
+      fill = "#41b6c4",
+      alpha = 0.5
+    ) +
+    ggplot2::geom_line(
+      ggplot2::aes(y = .data$medianv),
+      colour = "#253494",
+      size = size_text / 8
+    ) +
+    ggplot2::theme_bw(size_text) +
+    ggplot2::coord_cartesian(ylim = c(0, max_lambda)) +
+    ggplot2::ylab("Force-of-Infection") +
+    ggplot2::xlab("year")
+
+  if (!is.null(foi_sim)) {
+    if (nrow(foi_data) != length(foi_sim)) {
+      warn_msg <- paste0(
+        "`foi_sim` has different length than `exposure_years`. ",
+        "Dropping last elements of `foi_sim`"
       )
-
-      #--------
-      foi_data$medianv[1] <- NA
-      foi_data$lower[1] <- NA
-      foi_data$upper[1] <- NA
-
-      foi_plot <-
-        ggplot2::ggplot(foi_data, ggplot2::aes(x = .data$year)) +
-        ggplot2::geom_ribbon(
-          ggplot2::aes(
-            ymin = .data$lower,
-            ymax = .data$upper
-          ),
-          fill = "#41b6c4",
-          alpha = 0.5
-        ) +
+      warning(warn_msg)
+      remove_x_values <- length(foi_sim) - nrow(foi_data)
+      foi_sim_data <- data.frame(
+        year = foi_data$year,
+        foi_sim = foi_sim[-(1:remove_x_values)]
+      )
+      foi_plot <- foi_plot +
         ggplot2::geom_line(
-          ggplot2::aes(y = .data$medianv),
-          colour = "#253494",
+          data = foi_sim_data, ggplot2::aes(y = foi_sim),
+          colour = "#b30909",
           size = size_text / 8
-        ) +
-        ggplot2::theme_bw(size_text) +
-        ggplot2::coord_cartesian(ylim = c(0, max_lambda)) +
-        ggplot2::ylab("Force-of-Infection") +
-        ggplot2::xlab("Year")
-      # TODO Add warning for foi_sim of different length than exposure years
-      if (!is.null(foi_sim)) {
-        if (nrow(foi_data) != length(foi_sim)) {
-          remove_x_values <- length(foi_sim) - nrow(foi_data)
-          foi_sim_data <- data.frame(
-            year = foi_data$year,
-            foi_sim = foi_sim[-(1:remove_x_values)]
-          )
-          foi_plot <- foi_plot +
-            ggplot2::geom_line(
-              data = foi_sim_data, ggplot2::aes(y = foi_sim),
-              colour = "#b30909",
-              size = size_text / 8
-            )
-        } else {
-          foi_sim_data <- data.frame(
-            year = foi_data$year,
-            foi_sim = foi_sim
-          )
-          foi_plot <- foi_plot +
-            ggplot2::geom_line(
-              data = foi_sim_data, ggplot2::aes(y = foi_sim),
-              colour = "#b30909",
-              size = size_text / 8
-            )
-        }
-      }
+        )
+    } else {
+      foi_sim_data <- data.frame(
+        year = foi_data$year,
+        foi_sim = foi_sim
+      )
+      foi_plot <- foi_plot +
+        ggplot2::geom_line(
+          data = foi_sim_data, ggplot2::aes(y = foi_sim),
+          colour = "#b30909",
+          size = size_text / 8
+        )
     }
   }
 

--- a/man/get_prev_expanded.Rd
+++ b/man/get_prev_expanded.Rd
@@ -5,13 +5,7 @@
 \title{Function that generates an object containing the confidence interval based on
 a Force-of-Infection fitting}
 \usage{
-get_prev_expanded(
-  foi,
-  serodata,
-  predicted_prev_lower_quantile = 0.1,
-  predicted_prev_upper_quantile = 0.9,
-  bin_data = FALSE
-)
+get_prev_expanded(foi, serodata, alpha = 0.05, bin_data = FALSE, bin_step = 5)
 }
 \arguments{
 \item{foi}{Object containing the information of the force of infection. It is
@@ -31,14 +25,16 @@ were born}
 The last six columns can be added to \code{serodata} by means of the function
 \code{\link[=prepare_serodata]{prepare_serodata()}}.}
 
-\item{predicted_prev_lower_quantile}{Float specifying the lower quantile
-to be used in \code{predicted_prev} calculation}
+\item{alpha}{Probability threshold for statistical significance used for both
+the binomial confidence interval, and the lower and upper quantiles of the
+estimated prevalence.}
 
-\item{predicted_prev_upper_quantile}{Float specifying the upper quantile
-to be used in \code{predicted_prev} calculation}
+\item{bin_data}{Boolean. Use \code{TRUE} when age binning is preferred for plotting.
+If \code{TRUE}, \code{serodata} is binned by means of \code{prepare_bin_data};
+Otherwise, age groups are kept as originally input.}
 
-\item{bin_data}{If \code{TRUE}, \code{serodata} is binned by means of
-\code{prepare_bin_data}. Otherwise, age groups are kept as originally input.}
+\item{bin_step}{Integer specifying the age groups bin size to be used when
+\code{bin_data} is set to \code{TRUE}.}
 }
 \value{
 \code{prev_final}. The expanded prevalence data. This is used for plotting

--- a/man/plot_seromodel.Rd
+++ b/man/plot_seromodel.Rd
@@ -9,10 +9,11 @@ estimates plots.}
 plot_seromodel(
   seromodel_object,
   serodata,
-  predicted_prev_lower_quantile = 0.1,
-  predicted_prev_upper_quantile = 0.9,
+  alpha = 0.05,
   max_lambda = NA,
   size_text = 25,
+  bin_data = TRUE,
+  bin_step = 5,
   foi_sim = NULL
 )
 }
@@ -34,16 +35,21 @@ were born}
 The last six columns can be added to \code{serodata} by means of the function
 \code{\link[=prepare_serodata]{prepare_serodata()}}.}
 
-\item{predicted_prev_lower_quantile}{Float specifying the lower quantile
-to be used in \code{predicted_prev} calculation}
-
-\item{predicted_prev_upper_quantile}{Float specifying the upper quantile
-to be used in \code{predicted_prev} calculation}
+\item{alpha}{Probability threshold for statistical significance used for both
+the binomial confidence interval, and the lower and upper quantiles of the
+estimated prevalence.}
 
 \item{max_lambda}{TBD}
 
 \item{size_text}{Text size use in the theme of the graph returned by the
 function.}
+
+\item{bin_data}{Boolean. Use \code{TRUE} when age binning is preferred for plotting.
+If \code{TRUE}, \code{serodata} is binned by means of \code{prepare_bin_data};
+Otherwise, age groups are kept as originally input.}
+
+\item{bin_step}{Integer specifying the age groups bin size to be used when
+\code{bin_data} is set to \code{TRUE}.}
 
 \item{foi_sim}{TBD}
 }

--- a/man/plot_seroprev.Rd
+++ b/man/plot_seroprev.Rd
@@ -5,7 +5,7 @@
 \title{Function that generates the seropositivity plot from a raw serological
 survey dataset}
 \usage{
-plot_seroprev(serodata, size_text = 6)
+plot_seroprev(serodata, size_text = 6, bin_data = TRUE, bin_step = 5)
 }
 \arguments{
 \item{serodata}{A data frame containing the data from a serological survey.
@@ -28,6 +28,13 @@ by the function.}
 
 \item{size_text}{Text size use in the theme of the graph returned by the
 function.}
+
+\item{bin_data}{Boolean. Use \code{TRUE} when age binning is preferred for plotting.
+If \code{TRUE}, \code{serodata} is binned by means of \code{prepare_bin_data};
+Otherwise, age groups are kept as originally input.}
+
+\item{bin_step}{Integer specifying the age groups bin size to be used when
+\code{bin_data} is set to \code{TRUE}.}
 }
 \value{
 A ggplot object containing the seropositivity-vs-age graph of the raw

--- a/man/plot_seroprev_fitted.Rd
+++ b/man/plot_seroprev_fitted.Rd
@@ -8,9 +8,10 @@ fitted serological model}
 plot_seroprev_fitted(
   seromodel_object,
   serodata,
-  predicted_prev_lower_quantile = 0.1,
-  predicted_prev_upper_quantile = 0.9,
-  size_text = 6
+  size_text = 6,
+  bin_data = TRUE,
+  bin_step = 5,
+  alpha = 0.05
 )
 }
 \arguments{
@@ -31,13 +32,18 @@ were born}
 The last six columns can be added to \code{serodata} by means of the function
 \code{\link[=prepare_serodata]{prepare_serodata()}}.}
 
-\item{predicted_prev_lower_quantile}{Float specifying the lower quantile
-to be used in \code{predicted_prev} calculation}
-
-\item{predicted_prev_upper_quantile}{Float specifying the upper quantile
-to be used in \code{predicted_prev} calculation}
-
 \item{size_text}{Text size of the graph returned by the function.}
+
+\item{bin_data}{Boolean. Use \code{TRUE} when age binning is preferred for plotting.
+If \code{TRUE}, \code{serodata} is binned by means of \code{prepare_bin_data};
+Otherwise, age groups are kept as originally input.}
+
+\item{bin_step}{Integer specifying the age groups bin size to be used when
+\code{bin_data} is set to \code{TRUE}.}
+
+\item{alpha}{Probability threshold for statistical significance used for both
+the binomial confidence interval, and the lower and upper quantiles of the
+estimated prevalence.}
 }
 \value{
 A ggplot object containing the seropositivity-vs-age graph including

--- a/tests/testthat/test_constant_model.R
+++ b/tests/testthat/test_constant_model.R
@@ -30,6 +30,9 @@ test_that("Test constant model", {
 
   foi <- rstan::extract(model_object, "foi", inc_warmup = FALSE)[[1]]
   prev_expanded <- get_prev_expanded(foi, serodata = serodata)
+  # corrects benchmark length
+  prev_expanded_compare <- prev_expanded_compare[1:nrow(prev_expanded), ]
+
 
   # compares expanded prevalence with benchmark
   expect_true(

--- a/tests/testthat/test_tv_models.R
+++ b/tests/testthat/test_tv_models.R
@@ -30,6 +30,8 @@ test_that("Test tv_normal model", {
 
   foi <- rstan::extract(model_object, "foi", inc_warmup = FALSE)[[1]]
   prev_expanded <- get_prev_expanded(foi, serodata = serodata)
+  # corrects benchmark length
+  prev_expanded_compare <- prev_expanded_compare[1:nrow(prev_expanded), ]
 
   # compares expanded prevalence with benchmark
   expect_true(
@@ -66,9 +68,12 @@ test_that("Test tv_normal_log model", {
 
   foi <- rstan::extract(model_object, "foi", inc_warmup = FALSE)[[1]]
   prev_expanded <- get_prev_expanded(foi, serodata = serodata)
+  # corrects benchmark length
+  prev_expanded_compare <- prev_expanded_compare[1:nrow(prev_expanded), ]
+
 
   # compares expanded prevalence with benchmark
-  # We use dplyr::near() rather than expect_equal() to allow passing a vector 
+  # We use dplyr::near() rather than expect_equal() to allow passing a vector
   # of tolerances.
   expect_true(
     all(


### PR DESCRIPTION
This PR:
- closes #136 
- closes #129
- Allows for data binning in seroprevalence plots
- Changes age grouping behavior - Intervals are now open to the left and closed to the right (denoted as (a,b])
- Sets automatic xlim/ylim in seroprevalence plots
- Set both Bayesian credible intervals and frequentist confidence interval using single parameter `alpha` (set as default to 0.05)