### PR TITLE
Corrects documentation syntax across the package

### DIFF
--- a/R/model_comparison.R
+++ b/R/model_comparison.R
@@ -1,7 +1,7 @@
 #' Build dataframe containing the R-hat estimates for a given
 #' serological model
 #'
-#' This method relies in the function [rhat][bayesplot::rhat] to extract the
+#' This function relies on [rhat][bayesplot::rhat] to extract the
 #' R-hat estimates of the serological model object `seromodel_object` and
 #' returns a table a dataframe with the estimates for each year of birth.
 #' @inheritParams get_foi_central_estimates

--- a/R/model_comparison.R
+++ b/R/model_comparison.R
@@ -1,4 +1,4 @@
-#' Method for extracting a dataframe containing the R-hat estimates for a given
+#' Build dataframe containing the R-hat estimates for a given
 #' serological model
 #'
 #' This method relies in the function [rhat][bayesplot::rhat] to extract the

--- a/R/modelling.R
+++ b/R/modelling.R
@@ -173,7 +173,7 @@ run_seromodel <- function(
   return(seromodel_object)
 }
 
-#' Function that fits the selected model to the specified seroprevalence survey
+#' Fit selected model to the specified seroprevalence survey
 #' data
 #'
 #' This function fits the specified model `foi_model` to the serological survey

--- a/R/modelling.R
+++ b/R/modelling.R
@@ -110,7 +110,7 @@ validate_prepared_serodata <- function(serodata) {
   stop_if_wrong_type(serodata, col_types)
 }
 
-#' Function that runs the specified stan model for the Force-of-Infection and
+#' Run specified stan model for the force-of-infection and
 #' estimates the seroprevalence based on the result of the fit
 #'
 #' This function runs the specified model for the Force-of-Infection `foi_model`
@@ -307,7 +307,7 @@ fit_seromodel <- function(
 }
 
 
-#' Function that generates a data.frame containing the age of each cohort
+#' Generate data.frame containing the age of each cohort
 #' corresponding to each birth year excluding the year of the survey.
 #'
 #' This function generates a data.frame containing the age of each cohort
@@ -335,7 +335,7 @@ get_cohort_ages <- function(serodata) {
 
 # TODO Is necessary to explain better what we mean by the exposure matrix.
 
-#' Function that generates the exposure matrix corresponding to a serological
+#' Generate exposure matrix corresponding to a serological
 #' survey
 #'
 #' @inheritParams run_seromodel
@@ -359,7 +359,7 @@ get_exposure_matrix <- function(serodata) {
   return(exposure_output)
 }
 
-#' Function that generates the central estimates for the fitted forced FoI
+#' Extract central estimates for the fitted forced FoI
 #'
 #' @param seromodel_object Stanfit object containing the results of fitting a
 #'   model by means of [run_seromodel].

--- a/R/modelling.R
+++ b/R/modelling.R
@@ -111,7 +111,7 @@ validate_prepared_serodata <- function(serodata) {
 }
 
 #' Run specified stan model for the force-of-infection and
-#' estimates the seroprevalence based on the result of the fit
+#' estimate the seroprevalence based on the result of the fit
 #'
 #' This function runs the specified model for the force-of-infection `foi_model`
 #' using the data from a seroprevalence survey `serodata` as the input data. See
@@ -307,15 +307,15 @@ fit_seromodel <- function(
 }
 
 
-#' Generate data.frame containing the age of each cohort
+#' Generate data frame containing the age of each cohort
 #' corresponding to each birth year excluding the year of the survey.
 #'
-#' This function generates a data.frame containing the age of each cohort
+#' This function generates a data frame containing the age of each cohort
 #' corresponding to each `birth_year` excluding the year of the survey, for
 #' which the cohort age is still 0. specified serological survey data `serodata`
 #' excluding the year of the survey.
 #' @inheritParams run_seromodel
-#' @return `cohort_ages`. A data.frame containing the age of each cohort
+#' @return `cohort_ages`. A data frame containing the age of each cohort
 #'   corresponding to each birth year
 #' @examples
 #' data(chagas2012)
@@ -363,7 +363,7 @@ get_exposure_matrix <- function(serodata) {
 #'
 #' @param seromodel_object Stanfit object containing the results of fitting a
 #'   model by means of [run_seromodel].
-#' @param cohort_ages  A data.frame containing the age of each cohort
+#' @param cohort_ages  A data frame containing the age of each cohort
 #'   corresponding to each birth year.
 #' @return `foi_central_estimates`. Central estimates for the fitted forced FoI
 #' @examples
@@ -483,8 +483,9 @@ extract_seromodel_summary <- function(seromodel_object,
   return(model_summary)
 }
 
-#' Function that generates an object containing the confidence interval based on
-#' a Force-of-Infection fitting
+
+#' Generate data frame containing the confidence interval based on
+#' a force-of-infection fitting
 #'
 #' This function computes the corresponding binomial confidence intervals for
 #' the obtained prevalence based on a fitting of the force-of-infection `foi`
@@ -496,11 +497,12 @@ extract_seromodel_summary <- function(seromodel_object,
 #' the binomial confidence interval, and the lower and upper quantiles of the
 #' estimated prevalence.
 #' @inheritParams run_seromodel
-#' @param bin_data Boolean. Use `TRUE` when age binning is preferred for
-#' plotting. If `TRUE`, `serodata` is binned by means of
-#' `prepare_bin_data`; Otherwise, age groups are kept as originally input.
-#' @param bin_step Integer specifying the age groups bin size to be used when
-#' `bin_data` is set to `TRUE`.
+#' @param predicted_prev_lower_quantile Float specifying the lower quantile
+#'   to be used in `predicted_prev` calculation
+#' @param predicted_prev_upper_quantile Float specifying the upper quantile
+#'   to be used in `predicted_prev` calculation
+#' @param bin_data If `TRUE`, `serodata` is binned by means of
+#'   `prepare_bin_data`. Otherwise, age groups are kept as originally input.
 #' @return `prev_final`. The expanded prevalence data. This is used for plotting
 #'   purposes in the `visualization` module.
 #' @examples

--- a/R/modelling.R
+++ b/R/modelling.R
@@ -113,7 +113,7 @@ validate_prepared_serodata <- function(serodata) {
 #' Run specified stan model for the force-of-infection and
 #' estimates the seroprevalence based on the result of the fit
 #'
-#' This function runs the specified model for the Force-of-Infection `foi_model`
+#' This function runs the specified model for the force-of-infection `foi_model`
 #' using the data from a seroprevalence survey `serodata` as the input data. See
 #' [fit_seromodel] for further details.
 #'
@@ -390,7 +390,7 @@ get_foi_central_estimates <- function(seromodel_object,
     upper_quantile <- 0.95
     medianv_quantile <- 0.5
   }
-  # extracts foi from stan fit
+  # extracts force-of-infection from stan fit
   foi <- rstan::extract(seromodel_object, "foi", inc_warmup = FALSE)[[1]]
 
   # generates central estimations
@@ -487,9 +487,9 @@ extract_seromodel_summary <- function(seromodel_object,
 #' a Force-of-Infection fitting
 #'
 #' This function computes the corresponding binomial confidence intervals for
-#' the obtained prevalence based on a fitting of the Force-of-Infection `foi`
+#' the obtained prevalence based on a fitting of the force-of-infection `foi`
 #' for plotting an analysis purposes.
-#' @param foi Object containing the information of the force of infection. It is
+#' @param foi Object containing the information of the force-of-infection. It is
 #'   obtained from `rstan::extract(seromodel_object$seromodel, "foi", inc_warmup
 #'   = FALSE)[[1]]`.
 #' @param alpha Probability threshold for statistical significance used for both

--- a/R/modelling.R
+++ b/R/modelling.R
@@ -177,7 +177,7 @@ run_seromodel <- function(
 #' data
 #'
 #' This function fits the specified model `foi_model` to the serological survey
-#' data `serodata` by means of the [sampling][rstan::sampling] method. The
+#' data `serodata` by means of [sampling][rstan::sampling]. The
 #' function determines whether the corresponding stan model object needs to be
 #' compiled by rstan.
 #' @param serodata A data frame containing the data from a seroprevalence

--- a/R/seroprevalence_data.R
+++ b/R/seroprevalence_data.R
@@ -285,12 +285,12 @@ generate_sim_data <- function(sim_data,
 
 #' Construct age-group variable from age column
 #'
-#' This function was taken from [get_age_group][vaccineff::get_age_group].
-#' This method splits an age interval from age_min to age_max into
+#' Function taken from [get_age_group][vaccineff::get_age_group].
+#' This function splits an age interval from age_min to age_max into
 #' `(age_max-age_min)/step` intervals.
 #' By default age_min is set 0, however it can be assigned by
 #' convenience.
-#' If the method finds ages greater or equal than age_max
+#' If the function finds ages greater or equal than age_max
 #' it assigns the string `">{age_max}"`.
 #' To avoid errors it is necessary to set `step<age_max`.
 #' It is also suggested to choose the step such

--- a/R/seroprevalence_data.R
+++ b/R/seroprevalence_data.R
@@ -156,7 +156,7 @@ prepare_bin_data <- function(serodata,
 #'   \item{`tsur`}{Year of the survey}
 #' }
 #' @param foi Numeric atomic vector corresponding to the desired
-#'   Force-of-Infection ordered from past to present
+#'   force-of-infection ordered from past to present
 #' @return A dataframe containing the following columns:
 #' \describe{
 #'   \item{`age`}{Exposure ages}

--- a/R/seroprevalence_data.R
+++ b/R/seroprevalence_data.R
@@ -1,7 +1,7 @@
 # TODO Complete @param documentation
 
 
-#' Function that prepares the data from a serological survey for modelling
+#' Prepare data from a serological survey for modelling
 #'
 #' This function adds the necessary additional variables to the given dataset
 #' `serodata` corresponding to a serological survey.
@@ -84,8 +84,8 @@ prepare_serodata <- function(serodata = serodata,
 }
 
 
-#' Function that prepares a pre-processed serological survey dataset to plot the
-#' binomial confidence intervals of the seroprevalence grouped by age group
+#' Prepare pre-processed serological survey dataset to plot the
+#' binomial confidence intervals of the seroprevalence by age group
 #'
 #' This function prepapares a given pre-processed serological dataset (see
 #' [prepare_serodata()]) to plot the binomial confidence intervals of its
@@ -147,8 +147,8 @@ prepare_bin_data <- function(serodata,
   return(serodata_bin)
 }
 
-#' Function that generates the probabilities of being previously exposed to a
-#' pathogen given a historical Force-of-Infection.
+#' Generate probabilities of being previously exposed to a
+#' pathogen given a historical force-of-infection.
 #'
 #' @param sim_data A dataframe object containing the following columns:
 #' \describe{
@@ -187,7 +187,7 @@ get_sim_probability <- function(sim_data, foi) {
   return(sim_probability)
 }
 
-#' Function that generates a sample of counts of seropositive individuals by
+#' Generate sample of counts of seropositive individuals by
 #' sampling from a binomial distribution
 #'
 #' @inheritParams get_sim_probability
@@ -237,7 +237,7 @@ get_sim_n_seropositive <- function(sim_data,
   return(sim_n_seropositive)
 }
 
-#' Function that generates a simulated serosurvey according to the specified FoI
+#' Generate simulated serosurvey according to the specified FoI
 #'
 #' @inheritParams get_sim_n_seropositive
 #' @param survey_label Label for the resulting simulated serosurvey.
@@ -283,7 +283,7 @@ generate_sim_data <- function(sim_data,
   return(sim_data)
 }
 
-#' Method for constructing age-group variable from age column
+#' Construct age-group variable from age column
 #'
 #' This function was taken from [get_age_group][vaccineff::get_age_group].
 #' This method splits an age interval from age_min to age_max into
@@ -335,7 +335,7 @@ get_age_group <- function(age, step) {
   return(age_group)
 }
 
-#' Function that groups a simulated serological dataset by age
+#' Group simulated serological dataset by age
 #'
 #' @param sim_data Dataframe with the same structure as the output of
 #'   [generate_sim_data()].

--- a/R/simdata_constant.R
+++ b/R/simdata_constant.R
@@ -1,6 +1,6 @@
-#' Constant FoI simulated serosurvey
+#' Constant force-of-infection simulated serosurvey
 #'
-#' Simulated dataset describing a endemic situation where the Force-of-Infection
+#' Simulated dataset describing a endemic situation where the force-of-infection
 #' is constant over a period of 50 years (2000-2050) with a value of 0.2.
 #' The hypothetical serosurvey is conducted in year 2050 for 250 individuals
 #' that are up to 50 years old.

--- a/R/simdata_large_epi.R
+++ b/R/simdata_large_epi.R
@@ -1,7 +1,7 @@
 #' Large epidemic simulated serosurvey
 #'
 #' Simulated dataset describing a large epidemic between the years 2032 and 2035
-#' with a constant Force-of-Infection with value 1.5.
+#' with a constant force-of-infection with value 1.5.
 #' The hypothetical serosurvey is conducted in year 2050 for 250 individuals
 #' that are up to 50 years old.
 #'

--- a/R/simdata_sw_dec.R
+++ b/R/simdata_sw_dec.R
@@ -1,6 +1,6 @@
-#' Step-wise decreasing FoI simulated serosurvey
+#' Step-wise decreasing force-of-infection simulated serosurvey
 #'
-#' Simulated dataset describing a situation where the Force-of-Infection
+#' Simulated dataset describing a situation where the force-of-infection
 #' follows a step-wise decreasing tendency over a period of 50 years (2000-2050)
 #' The hypothetical serosurvey is conducted in year 2050 for 250 individuals
 #' that are up to 50 years old.

--- a/R/visualisation.R
+++ b/R/visualisation.R
@@ -159,16 +159,16 @@ plot_seroprev_fitted <- function(seromodel_object,
 #' Generate force-of-infection plot corresponding to the
 #' specified fitted serological model
 #'
-#' This function generates a Force-of-Infection plot from the results obtained
+#' This function generates a force-of-infection plot from the results obtained
 #' by fitting a serological model. This includes the corresponding binomial
 #' confidence interval. The x axis corresponds to the decades covered by the
-#' survey the y axis to the Force-of-Infection.
+#' survey the y axis to the force-of-infection.
 #' @inheritParams get_foi_central_estimates
 #' @param size_text Text size use in the theme of the graph returned by the
 #'   function.
 #' @param max_lambda TBD
 #' @param foi_sim TBD
-#' @return A ggplot2 object containing the Force-of-infection-vs-time including
+#' @return A ggplot2 object containing the force-of-infection vs time including
 #'   the corresponding confidence interval.
 #' @examples
 #' data(chagas2012)

--- a/R/visualisation.R
+++ b/R/visualisation.R
@@ -327,7 +327,7 @@ plot_rhats <- function(seromodel_object,
   return(rhats_plot)
 }
 
-#' Generate vertical arrange of plots showing a summary of a
+#' Generate vertical arrangement of plots showing a summary of a
 #' model, the estimated seroprevalence, the force-of-infection fit and the R-hat
 #' estimates plots.
 #'

--- a/R/visualisation.R
+++ b/R/visualisation.R
@@ -415,9 +415,9 @@ plot_seromodel <- function(seromodel_object,
 
 #' Generate plot summarizing a given table
 #'
-#' @param info the information that will be contained in the table
+#' @param info_table Table with the information to be summarised
 #' @param size_text Text size of the graph returned by the function
-#' @return p the plot for the given table
+#' @return ggplot object summarizing the information in `info_table`
 #' @examples
 #' serodata <- prepare_serodata(chagas2012)
 #' seromodel_object <- run_seromodel(
@@ -429,16 +429,19 @@ plot_seromodel <- function(seromodel_object,
 #'   seromodel_object = seromodel_object,
 #'   serodata = serodata
 #' )
-#' info <- t(seromodel_summary)
-#' plot_info_table(info, size_text = 15)
+#' info_table <- t(seromodel_summary)
+#' plot_info_table(info_table, size_text = 15)
 #' @export
-plot_info_table <- function(info, size_text) {
+plot_info_table <- function(info_table, size_text) {
   dato <- data.frame(
-    y = NROW(info):seq_len(1),
-    text = paste0(rownames(info), ": ", info[, 1])
+    y = NROW(info_table):seq_len(1),
+    text = paste0(rownames(info_table), ": ", info_table[, 1])
   )
   p <- ggplot2::ggplot(dato, ggplot2::aes(x = 1, y = .data$y)) +
-    ggplot2::scale_y_continuous(limits = c(0, NROW(info) + 1), breaks = NULL) +
+    ggplot2::scale_y_continuous(
+      limits = c(0, NROW(info_table) + 1),
+      breaks = NULL
+      ) +
     ggplot2::theme_void() +
     ggplot2::geom_text(ggplot2::aes(label = text),
       size = size_text / 2.5,

--- a/R/visualisation.R
+++ b/R/visualisation.R
@@ -1,4 +1,4 @@
-#' Function that generates the seropositivity plot from a raw serological
+#' Generate seropositivity plot from a raw serological
 #' survey dataset
 #'
 #' @inheritParams prepare_serodata
@@ -71,7 +71,7 @@ plot_seroprev <- function(serodata,
   return(seroprev_plot)
 }
 
-#' Function that generates a seropositivity plot corresponding to the specified
+#' Generate seropositivity plot corresponding to the specified
 #' fitted serological model
 #'
 #' This function generates a seropositivity plot of the specified serological
@@ -156,7 +156,7 @@ plot_seroprev_fitted <- function(seromodel_object,
 
 # TODO Complete @param documentation
 
-#' Function that generates a Force-of-Infection plot corresponding to the
+#' Generate force-of-infection plot corresponding to the
 #' specified fitted serological model
 #'
 #' This function generates a Force-of-Infection plot from the results obtained
@@ -252,7 +252,7 @@ plot_foi <- function(seromodel_object,
   return(foi_plot)
 }
 
-#' Function that generates a plot of the R-hat estimates of the specified fitted
+#' Generate plot of the R-hat estimates for the specified fitted
 #' serological model
 #'
 #' This function generates a plot of the R-hat estimates obtained for a
@@ -327,10 +327,8 @@ plot_rhats <- function(seromodel_object,
   return(rhats_plot)
 }
 
-# TODO Complete @param documentation
-
-#' Function that generates a vertical arrange of plots showing a summary of a
-#' model, the estimated seroprevalence, the Force-of-Infection fit and the R-hat
+#' Generate vertical arrange of plots showing a summary of a
+#' model, the estimated seroprevalence, the force-of-infection fit and the R-hat
 #' estimates plots.
 #'
 #' @inheritParams get_foi_central_estimates
@@ -415,9 +413,7 @@ plot_seromodel <- function(seromodel_object,
   return(plot_arrange)
 }
 
-# TODO Improve documentation of @return.
-# TODO Give more details about the generated plot
-#' Function that generates a plot for a given table
+#' Generate plot summarizing a given table
 #'
 #' @param info the information that will be contained in the table
 #' @param size_text Text size of the graph returned by the function

--- a/man/fit_seromodel.Rd
+++ b/man/fit_seromodel.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/modelling.R
 \name{fit_seromodel}
 \alias{fit_seromodel}
-\title{Function that fits the selected model to the specified seroprevalence survey
+\title{Fit selected model to the specified seroprevalence survey
 data}
 \usage{
 fit_seromodel(
@@ -70,7 +70,7 @@ to the \code{chains} parameter in \link[rstan:stanmodel-method-sampling]{samplin
 }
 \description{
 This function fits the specified model \code{foi_model} to the serological survey
-data \code{serodata} by means of the \link[rstan:stanmodel-method-sampling]{sampling} method. The
+data \code{serodata} by means of \link[rstan:stanmodel-method-sampling]{sampling}. The
 function determines whether the corresponding stan model object needs to be
 compiled by rstan.
 }

--- a/man/generate_sim_data.Rd
+++ b/man/generate_sim_data.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/seroprevalence_data.R
 \name{generate_sim_data}
 \alias{generate_sim_data}
-\title{Function that generates a simulated serosurvey according to the specified FoI}
+\title{Generate simulated serosurvey according to the specified FoI}
 \usage{
 generate_sim_data(sim_data, foi, sample_size_by_age, survey_label, seed = 1234)
 }
@@ -14,7 +14,7 @@ generate_sim_data(sim_data, foi, sample_size_by_age, survey_label, seed = 1234)
 }}
 
 \item{foi}{Numeric atomic vector corresponding to the desired
-Force-of-Infection ordered from past to present}
+force-of-infection ordered from past to present}
 
 \item{sample_size_by_age}{Integer indicating the sample size by age group.
 This corresponds to the number of trials \code{size} in \link[stats:Binomial]{rbinom}.}
@@ -27,7 +27,7 @@ This corresponds to the number of trials \code{size} in \link[stats:Binomial]{rb
 Dataframe containing the simulated serosurvey.
 }
 \description{
-Function that generates a simulated serosurvey according to the specified FoI
+Generate simulated serosurvey according to the specified FoI
 }
 \examples{
 n_years <- 50

--- a/man/get_age_group.Rd
+++ b/man/get_age_group.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/seroprevalence_data.R
 \name{get_age_group}
 \alias{get_age_group}
-\title{Method for constructing age-group variable from age column}
+\title{Construct age-group variable from age column}
 \usage{
 get_age_group(age, step)
 }
@@ -16,12 +16,12 @@ age_group factor variable grouping \code{age} by the age intervals
 specified by \code{min(age)}, \code{max(age)}.
 }
 \description{
-This function was taken from \link[vaccineff:get_age_group]{get_age_group}.
-This method splits an age interval from age_min to age_max into
+Function taken from \link[vaccineff:get_age_group]{get_age_group}.
+This function splits an age interval from age_min to age_max into
 \code{(age_max-age_min)/step} intervals.
 By default age_min is set 0, however it can be assigned by
 convenience.
-If the method finds ages greater or equal than age_max
+If the function finds ages greater or equal than age_max
 it assigns the string \code{">{age_max}"}.
 To avoid errors it is necessary to set \code{step<age_max}.
 It is also suggested to choose the step such

--- a/man/get_cohort_ages.Rd
+++ b/man/get_cohort_ages.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/modelling.R
 \name{get_cohort_ages}
 \alias{get_cohort_ages}
-\title{Function that generates a data.frame containing the age of each cohort
+\title{Generate data.frame containing the age of each cohort
 corresponding to each birth year excluding the year of the survey.}
 \usage{
 get_cohort_ages(serodata)

--- a/man/get_cohort_ages.Rd
+++ b/man/get_cohort_ages.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/modelling.R
 \name{get_cohort_ages}
 \alias{get_cohort_ages}
-\title{Generate data.frame containing the age of each cohort
+\title{Generate data frame containing the age of each cohort
 corresponding to each birth year excluding the year of the survey.}
 \usage{
 get_cohort_ages(serodata)
@@ -23,11 +23,11 @@ The last six columns can be added to \code{serodata} by means of the function
 \code{\link[=prepare_serodata]{prepare_serodata()}}.}
 }
 \value{
-\code{cohort_ages}. A data.frame containing the age of each cohort
+\code{cohort_ages}. A data frame containing the age of each cohort
 corresponding to each birth year
 }
 \description{
-This function generates a data.frame containing the age of each cohort
+This function generates a data frame containing the age of each cohort
 corresponding to each \code{birth_year} excluding the year of the survey, for
 which the cohort age is still 0. specified serological survey data \code{serodata}
 excluding the year of the survey.

--- a/man/get_foi_central_estimates.Rd
+++ b/man/get_foi_central_estimates.Rd
@@ -10,7 +10,7 @@ get_foi_central_estimates(seromodel_object, cohort_ages)
 \item{seromodel_object}{Stanfit object containing the results of fitting a
 model by means of \link{run_seromodel}.}
 
-\item{cohort_ages}{A data.frame containing the age of each cohort
+\item{cohort_ages}{A data frame containing the age of each cohort
 corresponding to each birth year.}
 }
 \value{

--- a/man/get_foi_central_estimates.Rd
+++ b/man/get_foi_central_estimates.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/modelling.R
 \name{get_foi_central_estimates}
 \alias{get_foi_central_estimates}
-\title{Function that generates the central estimates for the fitted forced FoI}
+\title{Extract central estimates for the fitted forced FoI}
 \usage{
 get_foi_central_estimates(seromodel_object, cohort_ages)
 }
@@ -17,7 +17,7 @@ corresponding to each birth year.}
 \code{foi_central_estimates}. Central estimates for the fitted forced FoI
 }
 \description{
-Function that generates the central estimates for the fitted forced FoI
+Extract central estimates for the fitted forced FoI
 }
 \examples{
 data(chagas2012)

--- a/man/get_prev_expanded.Rd
+++ b/man/get_prev_expanded.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/modelling.R
 \name{get_prev_expanded}
 \alias{get_prev_expanded}
-\title{Generate object containing the confidence interval based on
+\title{Generate data frame containing the confidence interval based on
 a force-of-infection fitting}
 \usage{
 get_prev_expanded(foi, serodata, alpha = 0.05, bin_data = FALSE, bin_step = 5)

--- a/man/get_prev_expanded.Rd
+++ b/man/get_prev_expanded.Rd
@@ -2,13 +2,13 @@
 % Please edit documentation in R/modelling.R
 \name{get_prev_expanded}
 \alias{get_prev_expanded}
-\title{Function that generates an object containing the confidence interval based on
-a Force-of-Infection fitting}
+\title{Generate object containing the confidence interval based on
+a force-of-infection fitting}
 \usage{
 get_prev_expanded(foi, serodata, alpha = 0.05, bin_data = FALSE, bin_step = 5)
 }
 \arguments{
-\item{foi}{Object containing the information of the force of infection. It is
+\item{foi}{Object containing the information of the force-of-infection. It is
 obtained from \code{rstan::extract(seromodel_object$seromodel, "foi", inc_warmup = FALSE)[[1]]}.}
 
 \item{serodata}{A data frame containing the data from a seroprevalence
@@ -42,7 +42,7 @@ purposes in the \code{visualization} module.
 }
 \description{
 This function computes the corresponding binomial confidence intervals for
-the obtained prevalence based on a fitting of the Force-of-Infection \code{foi}
+the obtained prevalence based on a fitting of the force-of-infection \code{foi}
 for plotting an analysis purposes.
 }
 \examples{

--- a/man/get_sim_n_seropositive.Rd
+++ b/man/get_sim_n_seropositive.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/seroprevalence_data.R
 \name{get_sim_n_seropositive}
 \alias{get_sim_n_seropositive}
-\title{Function that generates a sample of counts of seropositive individuals by
+\title{Generate sample of counts of seropositive individuals by
 sampling from a binomial distribution}
 \usage{
 get_sim_n_seropositive(sim_data, foi, sample_size_by_age, seed = 1234)
@@ -15,7 +15,7 @@ get_sim_n_seropositive(sim_data, foi, sample_size_by_age, seed = 1234)
 }}
 
 \item{foi}{Numeric atomic vector corresponding to the desired
-Force-of-Infection ordered from past to present}
+force-of-infection ordered from past to present}
 
 \item{sample_size_by_age}{Integer indicating the sample size by age group.
 This corresponds to the number of trials \code{size} in \link[stats:Binomial]{rbinom}.}
@@ -33,7 +33,7 @@ simulated list of counts following a binomial distribution in accordance
 with a given force of infection and age group sizes.
 }
 \description{
-Function that generates a sample of counts of seropositive individuals by
+Generate sample of counts of seropositive individuals by
 sampling from a binomial distribution
 }
 \examples{

--- a/man/get_sim_probability.Rd
+++ b/man/get_sim_probability.Rd
@@ -2,8 +2,8 @@
 % Please edit documentation in R/seroprevalence_data.R
 \name{get_sim_probability}
 \alias{get_sim_probability}
-\title{Function that generates the probabilities of being previously exposed to a
-pathogen given a historical Force-of-Infection.}
+\title{Generate probabilities of being previously exposed to a
+pathogen given a historical force-of-infection.}
 \usage{
 get_sim_probability(sim_data, foi)
 }
@@ -15,7 +15,7 @@ get_sim_probability(sim_data, foi)
 }}
 
 \item{foi}{Numeric atomic vector corresponding to the desired
-Force-of-Infection ordered from past to present}
+force-of-infection ordered from past to present}
 }
 \value{
 A dataframe containing the following columns:
@@ -26,8 +26,8 @@ according to the provided FoI}
 }
 }
 \description{
-Function that generates the probabilities of being previously exposed to a
-pathogen given a historical Force-of-Infection.
+Generate probabilities of being previously exposed to a
+pathogen given a historical force-of-infection.
 }
 \examples{
 n_years <- 50

--- a/man/get_table_rhats.Rd
+++ b/man/get_table_rhats.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/model_comparison.R
 \name{get_table_rhats}
 \alias{get_table_rhats}
-\title{Method for extracting a dataframe containing the R-hat estimates for a given
+\title{Build dataframe containing the R-hat estimates for a given
 serological model}
 \usage{
 get_table_rhats(seromodel_object, cohort_ages)
@@ -18,7 +18,7 @@ corresponding to each birth year.}
 rhats table
 }
 \description{
-This method relies in the function \link[bayesplot:bayesplot-extractors]{rhat} to extract the
+This function relies on \link[bayesplot:bayesplot-extractors]{rhat} to extract the
 R-hat estimates of the serological model object \code{seromodel_object} and
 returns a table a dataframe with the estimates for each year of birth.
 }

--- a/man/get_table_rhats.Rd
+++ b/man/get_table_rhats.Rd
@@ -11,7 +11,7 @@ get_table_rhats(seromodel_object, cohort_ages)
 \item{seromodel_object}{Stanfit object containing the results of fitting a
 model by means of \link{run_seromodel}.}
 
-\item{cohort_ages}{A data.frame containing the age of each cohort
+\item{cohort_ages}{A data frame containing the age of each cohort
 corresponding to each birth year.}
 }
 \value{

--- a/man/group_sim_data.Rd
+++ b/man/group_sim_data.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/seroprevalence_data.R
 \name{group_sim_data}
 \alias{group_sim_data}
-\title{Function that groups a simulated serological dataset by age}
+\title{Group simulated serological dataset by age}
 \usage{
 group_sim_data(sim_data, col_age = "age_mean_f", step = 5)
 }
@@ -19,5 +19,5 @@ Dataframe object containing grouped simulated data generated from
 \code{foi}
 }
 \description{
-Function that groups a simulated serological dataset by age
+Group simulated serological dataset by age
 }

--- a/man/plot_foi.Rd
+++ b/man/plot_foi.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/visualisation.R
 \name{plot_foi}
 \alias{plot_foi}
-\title{Function that generates a Force-of-Infection plot corresponding to the
+\title{Generate force-of-infection plot corresponding to the
 specified fitted serological model}
 \usage{
 plot_foi(
@@ -28,14 +28,14 @@ function.}
 \item{foi_sim}{TBD}
 }
 \value{
-A ggplot2 object containing the Force-of-infection-vs-time including
+A ggplot2 object containing the force-of-infection vs time including
 the corresponding confidence interval.
 }
 \description{
-This function generates a Force-of-Infection plot from the results obtained
+This function generates a force-of-infection plot from the results obtained
 by fitting a serological model. This includes the corresponding binomial
 confidence interval. The x axis corresponds to the decades covered by the
-survey the y axis to the Force-of-Infection.
+survey the y axis to the force-of-infection.
 }
 \examples{
 data(chagas2012)

--- a/man/plot_foi.Rd
+++ b/man/plot_foi.Rd
@@ -17,7 +17,7 @@ plot_foi(
 \item{seromodel_object}{Stanfit object containing the results of fitting a
 model by means of \link{run_seromodel}.}
 
-\item{cohort_ages}{A data.frame containing the age of each cohort
+\item{cohort_ages}{A data frame containing the age of each cohort
 corresponding to each birth year.}
 
 \item{max_lambda}{TBD}

--- a/man/plot_info_table.Rd
+++ b/man/plot_info_table.Rd
@@ -2,20 +2,20 @@
 % Please edit documentation in R/visualisation.R
 \name{plot_info_table}
 \alias{plot_info_table}
-\title{Function that generates a plot for a given table}
+\title{Generate plot summarizing a given table}
 \usage{
-plot_info_table(info, size_text)
+plot_info_table(info_table, size_text)
 }
 \arguments{
-\item{info}{the information that will be contained in the table}
+\item{info_table}{Table with the information to be summarised}
 
 \item{size_text}{Text size of the graph returned by the function}
 }
 \value{
-p the plot for the given table
+ggplot object summarizing the information in \code{info_table}
 }
 \description{
-Function that generates a plot for a given table
+Generate plot summarizing a given table
 }
 \examples{
 serodata <- prepare_serodata(chagas2012)
@@ -28,6 +28,6 @@ seromodel_summary <- extract_seromodel_summary(
   seromodel_object = seromodel_object,
   serodata = serodata
 )
-info <- t(seromodel_summary)
-plot_info_table(info, size_text = 15)
+info_table <- t(seromodel_summary)
+plot_info_table(info_table, size_text = 15)
 }

--- a/man/plot_rhats.Rd
+++ b/man/plot_rhats.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/visualisation.R
 \name{plot_rhats}
 \alias{plot_rhats}
-\title{Function that generates a plot of the R-hat estimates of the specified fitted
+\title{Generate plot of the R-hat estimates for the specified fitted
 serological model}
 \usage{
 plot_rhats(seromodel_object, cohort_ages, size_text = 25)

--- a/man/plot_rhats.Rd
+++ b/man/plot_rhats.Rd
@@ -11,7 +11,7 @@ plot_rhats(seromodel_object, cohort_ages, size_text = 25)
 \item{seromodel_object}{Stanfit object containing the results of fitting a
 model by means of \link{run_seromodel}.}
 
-\item{cohort_ages}{A data.frame containing the age of each cohort
+\item{cohort_ages}{A data frame containing the age of each cohort
 corresponding to each birth year.}
 
 \item{size_text}{Text size use in the theme of the graph returned by the

--- a/man/plot_seromodel.Rd
+++ b/man/plot_seromodel.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/visualisation.R
 \name{plot_seromodel}
 \alias{plot_seromodel}
-\title{Generate vertical arrange of plots showing a summary of a
+\title{Generate vertical arrangement of plots showing a summary of a
 model, the estimated seroprevalence, the force-of-infection fit and the R-hat
 estimates plots.}
 \usage{
@@ -58,7 +58,7 @@ A ggplot object with a vertical arrange containing the
 seropositivity, force of infection, and convergence plots.
 }
 \description{
-Generate vertical arrange of plots showing a summary of a
+Generate vertical arrangement of plots showing a summary of a
 model, the estimated seroprevalence, the force-of-infection fit and the R-hat
 estimates plots.
 }

--- a/man/plot_seromodel.Rd
+++ b/man/plot_seromodel.Rd
@@ -2,8 +2,8 @@
 % Please edit documentation in R/visualisation.R
 \name{plot_seromodel}
 \alias{plot_seromodel}
-\title{Function that generates a vertical arrange of plots showing a summary of a
-model, the estimated seroprevalence, the Force-of-Infection fit and the R-hat
+\title{Generate vertical arrange of plots showing a summary of a
+model, the estimated seroprevalence, the force-of-infection fit and the R-hat
 estimates plots.}
 \usage{
 plot_seromodel(
@@ -58,8 +58,8 @@ A ggplot object with a vertical arrange containing the
 seropositivity, force of infection, and convergence plots.
 }
 \description{
-Function that generates a vertical arrange of plots showing a summary of a
-model, the estimated seroprevalence, the Force-of-Infection fit and the R-hat
+Generate vertical arrange of plots showing a summary of a
+model, the estimated seroprevalence, the force-of-infection fit and the R-hat
 estimates plots.
 }
 \examples{

--- a/man/plot_seroprev.Rd
+++ b/man/plot_seroprev.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/visualisation.R
 \name{plot_seroprev}
 \alias{plot_seroprev}
-\title{Function that generates the seropositivity plot from a raw serological
+\title{Generate seropositivity plot from a raw serological
 survey dataset}
 \usage{
 plot_seroprev(serodata, size_text = 6, bin_data = TRUE, bin_step = 5)
@@ -42,7 +42,7 @@ data of a given seroprevalence survey with its corresponding binomial
 confidence interval.
 }
 \description{
-Function that generates the seropositivity plot from a raw serological
+Generate seropositivity plot from a raw serological
 survey dataset
 }
 \examples{

--- a/man/plot_seroprev_fitted.Rd
+++ b/man/plot_seroprev_fitted.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/visualisation.R
 \name{plot_seroprev_fitted}
 \alias{plot_seroprev_fitted}
-\title{Function that generates a seropositivity plot corresponding to the specified
+\title{Generate seropositivity plot corresponding to the specified
 fitted serological model}
 \usage{
 plot_seroprev_fitted(

--- a/man/prepare_serodata.Rd
+++ b/man/prepare_serodata.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/seroprevalence_data.R
 \name{prepare_serodata}
 \alias{prepare_serodata}
-\title{Function that prepares the data from a serological survey for modelling}
+\title{Prepare data from a serological survey for modelling}
 \usage{
 prepare_serodata(serodata = serodata, alpha = 0.05)
 }

--- a/man/run_seromodel.Rd
+++ b/man/run_seromodel.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/modelling.R
 \name{run_seromodel}
 \alias{run_seromodel}
-\title{Function that runs the specified stan model for the Force-of-Infection and
+\title{Run specified stan model for the force-of-infection and
 estimates the seroprevalence based on the result of the fit}
 \usage{
 run_seromodel(
@@ -74,7 +74,7 @@ the implementation of the model. For further details refer to
 \link{fit_seromodel}.
 }
 \description{
-This function runs the specified model for the Force-of-Infection \code{foi_model}
+This function runs the specified model for the force-of-infection \code{foi_model}
 using the data from a seroprevalence survey \code{serodata} as the input data. See
 \link{fit_seromodel} for further details.
 }

--- a/man/run_seromodel.Rd
+++ b/man/run_seromodel.Rd
@@ -3,7 +3,7 @@
 \name{run_seromodel}
 \alias{run_seromodel}
 \title{Run specified stan model for the force-of-infection and
-estimates the seroprevalence based on the result of the fit}
+estimate the seroprevalence based on the result of the fit}
 \usage{
 run_seromodel(
   serodata,

--- a/man/simdata_constant.Rd
+++ b/man/simdata_constant.Rd
@@ -3,7 +3,7 @@
 \docType{data}
 \name{simdata_constant}
 \alias{simdata_constant}
-\title{Constant FoI simulated serosurvey}
+\title{Constant force-of-infection simulated serosurvey}
 \format{
 An object of class \code{"cross"}; see \code{\link[qtl:read.cross]{qtl::read.cross()}}.
 }
@@ -11,7 +11,7 @@ An object of class \code{"cross"}; see \code{\link[qtl:read.cross]{qtl::read.cro
 simdata_constant
 }
 \description{
-Simulated dataset describing a endemic situation where the Force-of-Infection
+Simulated dataset describing a endemic situation where the force-of-infection
 is constant over a period of 50 years (2000-2050) with a value of 0.2.
 The hypothetical serosurvey is conducted in year 2050 for 250 individuals
 that are up to 50 years old.

--- a/man/simdata_large_epi.Rd
+++ b/man/simdata_large_epi.Rd
@@ -12,7 +12,7 @@ simdata_large_epi
 }
 \description{
 Simulated dataset describing a large epidemic between the years 2032 and 2035
-with a constant Force-of-Infection with value 1.5.
+with a constant force-of-infection with value 1.5.
 The hypothetical serosurvey is conducted in year 2050 for 250 individuals
 that are up to 50 years old.
 }

--- a/man/simdata_sw_dec.Rd
+++ b/man/simdata_sw_dec.Rd
@@ -3,7 +3,7 @@
 \docType{data}
 \name{simdata_sw_dec}
 \alias{simdata_sw_dec}
-\title{Step-wise decreasing FoI simulated serosurvey}
+\title{Step-wise decreasing force-of-infection simulated serosurvey}
 \format{
 An object of class \code{"cross"}; see \code{\link[qtl:read.cross]{qtl::read.cross()}}.
 }
@@ -11,7 +11,7 @@ An object of class \code{"cross"}; see \code{\link[qtl:read.cross]{qtl::read.cro
 simdata_sw_dec
 }
 \description{
-Simulated dataset describing a situation where the Force-of-Infection
+Simulated dataset describing a situation where the force-of-infection
 follows a step-wise decreasing tendency over a period of 50 years (2000-2050)
 The hypothetical serosurvey is conducted in year 2050 for 250 individuals
 that are up to 50 years old.


### PR DESCRIPTION
This PR:
- closes #163.
- correct some minor syntax problems I identified along the way
- replace `info` by `info_table` in `get_info_table`

@ben18785 please point me out to any other syntax changes you are aware of that need to be done. 
