### PR TITLE
Deprecate `run_seromodel`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: serofoi
 Type: Package
 Title: Estimates the Force-of-Infection of a given pathogen from population based seroprevalence studies
-Version: 0.0.9.1
+Version: 0.1.0
 Authors@R: 
     c(
         person(
@@ -36,7 +36,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 Language: en-GB
 LazyData: true
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 NeedsCompilation: yes
 Depends: 
     R (>= 3.5.0)

--- a/R/model_comparison.R
+++ b/R/model_comparison.R
@@ -9,7 +9,7 @@
 #' @examples
 #' data(chagas2012)
 #' serodata <- prepare_serodata(serodata = chagas2012)
-#' model_constant <- run_seromodel(
+#' model_constant <- fit_seromodel(
 #'   serodata = serodata,
 #'   foi_model = "constant",
 #'   iter = 1500

--- a/R/modelling.R
+++ b/R/modelling.R
@@ -137,12 +137,14 @@ validate_prepared_serodata <- function(serodata) {
 #'   the implementation of the model. For further details refer to
 #'   [fit_seromodel].
 #' @examples
+#' \dontrun{
 #' data(chagas2012)
 #' serodata <- prepare_serodata(chagas2012)
 #' run_seromodel(
 #'   serodata,
 #'   foi_model = "constant"
 #' )
+#' }
 #' @export
 run_seromodel <- function(
     serodata,
@@ -512,7 +514,7 @@ get_foi_central_estimates <- function(seromodel_object,
 #' @examples
 #' data(chagas2012)
 #' serodata <- prepare_serodata(chagas2012)
-#' seromodel_object <- run_seromodel(
+#' seromodel_object <- fit_seromodel(
 #'   serodata = serodata,
 #'   foi_model = "constant"
 #' )
@@ -587,7 +589,7 @@ extract_seromodel_summary <- function(seromodel_object,
 #' @examples
 #' data(chagas2012)
 #' serodata <- prepare_serodata(chagas2012)
-#' seromodel_object <- run_seromodel(
+#' seromodel_object <- fit_seromodel(
 #'   serodata = serodata,
 #'   foi_model = "constant"
 #' )

--- a/R/modelling.R
+++ b/R/modelling.R
@@ -124,6 +124,8 @@ validate_prepared_serodata <- function(serodata) {
 #' Run specified stan model for the force-of-infection and
 #' estimate the seroprevalence based on the result of the fit
 #'
+#' Starting on v.0.1.0, this function will be DEPRECATED. Use `fit_seromodel`
+#' instead.
 #' This function runs the specified model for the force-of-infection `foi_model`
 #' using the data from a seroprevalence survey `serodata` as the input data. See
 #' [fit_seromodel] for further details.
@@ -155,6 +157,7 @@ run_seromodel <- function(
     seed = 12345,
     print_summary = TRUE,
     ...) {
+  .Deprecated("fit_seromodel")
   foi_model <- match.arg(foi_model)
   survey <- unique(serodata$survey)
   if (length(survey) > 1) {

--- a/R/visualisation.R
+++ b/R/visualisation.R
@@ -87,7 +87,7 @@ plot_seroprev <- function(serodata,
 #' @examples
 #' data(chagas2012)
 #' serodata <- prepare_serodata(chagas2012)
-#' seromodel_object <- run_seromodel(
+#' seromodel_object <- fit_seromodel(
 #'   serodata = serodata,
 #'   foi_model = "constant",
 #'   iter = 1000
@@ -173,7 +173,7 @@ plot_seroprev_fitted <- function(seromodel_object,
 #' @examples
 #' data(chagas2012)
 #' serodata <- prepare_serodata(chagas2012)
-#' seromodel_object <- run_seromodel(
+#' seromodel_object <- fit_seromodel(
 #'   serodata = serodata,
 #'   foi_model = "constant",
 #'   iter = 1000
@@ -267,7 +267,7 @@ plot_foi <- function(seromodel_object,
 #' @examples
 #' data(chagas2012)
 #' serodata <- prepare_serodata(chagas2012)
-#' seromodel_object <- run_seromodel(
+#' seromodel_object <- fit_seromodel(
 #'   serodata = serodata,
 #'   foi_model = "constant",
 #'   iter = 1000
@@ -343,7 +343,7 @@ plot_rhats <- function(seromodel_object,
 #' @examples
 #' data(chagas2012)
 #' serodata <- prepare_serodata(chagas2012)
-#' seromodel_object <- run_seromodel(
+#' seromodel_object <- fit_seromodel(
 #'   serodata = serodata,
 #'   foi_model = "constant",
 #'   iter = 1000
@@ -421,7 +421,7 @@ plot_seromodel <- function(seromodel_object,
 #' @return ggplot object summarizing the information in `info_table`
 #' @examples
 #' serodata <- prepare_serodata(chagas2012)
-#' seromodel_object <- run_seromodel(
+#' seromodel_object <- fit_seromodel(
 #'   serodata = serodata,
 #'   foi_model = "constant",
 #'   iter = 1000

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -24,6 +24,7 @@ Darien
 de
 Dib
 disaggregated
+Domínguez
 each
 elpd
 Epiverse
@@ -56,6 +57,7 @@ Pittí
 Pontificia
 Programmes
 Quevedo
+ORCID
 rbinom
 rhat
 rhats

--- a/man/extract_seromodel_summary.Rd
+++ b/man/extract_seromodel_summary.Rd
@@ -53,7 +53,7 @@ convergence of the model, like the expected log pointwise predictive density
 \examples{
 data(chagas2012)
 serodata <- prepare_serodata(chagas2012)
-seromodel_object <- run_seromodel(
+seromodel_object <- fit_seromodel(
   serodata = serodata,
   foi_model = "constant"
 )

--- a/man/get_prev_expanded.Rd
+++ b/man/get_prev_expanded.Rd
@@ -47,7 +47,7 @@ for plotting an analysis purposes.
 \examples{
 data(chagas2012)
 serodata <- prepare_serodata(chagas2012)
-seromodel_object <- run_seromodel(
+seromodel_object <- fit_seromodel(
   serodata = serodata,
   foi_model = "constant"
 )

--- a/man/get_table_rhats.Rd
+++ b/man/get_table_rhats.Rd
@@ -25,7 +25,7 @@ returns a table a dataframe with the estimates for each year of birth.
 \examples{
 data(chagas2012)
 serodata <- prepare_serodata(serodata = chagas2012)
-model_constant <- run_seromodel(
+model_constant <- fit_seromodel(
   serodata = serodata,
   foi_model = "constant",
   iter = 1500

--- a/man/plot_foi.Rd
+++ b/man/plot_foi.Rd
@@ -40,7 +40,7 @@ survey the y axis to the force-of-infection.
 \examples{
 data(chagas2012)
 serodata <- prepare_serodata(chagas2012)
-seromodel_object <- run_seromodel(
+seromodel_object <- fit_seromodel(
   serodata = serodata,
   foi_model = "constant",
   iter = 1000

--- a/man/plot_info_table.Rd
+++ b/man/plot_info_table.Rd
@@ -19,7 +19,7 @@ Generate plot summarizing a given table
 }
 \examples{
 serodata <- prepare_serodata(chagas2012)
-seromodel_object <- run_seromodel(
+seromodel_object <- fit_seromodel(
   serodata = serodata,
   foi_model = "constant",
   iter = 1000

--- a/man/plot_rhats.Rd
+++ b/man/plot_rhats.Rd
@@ -30,7 +30,7 @@ details check \link[bayesplot:bayesplot-extractors]{rhat}).
 \examples{
 data(chagas2012)
 serodata <- prepare_serodata(chagas2012)
-seromodel_object <- run_seromodel(
+seromodel_object <- fit_seromodel(
   serodata = serodata,
   foi_model = "constant",
   iter = 1000

--- a/man/plot_seromodel.Rd
+++ b/man/plot_seromodel.Rd
@@ -64,7 +64,7 @@ estimates plots.
 \examples{
 data(chagas2012)
 serodata <- prepare_serodata(chagas2012)
-seromodel_object <- run_seromodel(
+seromodel_object <- fit_seromodel(
   serodata = serodata,
   foi_model = "constant",
   iter = 1000

--- a/man/plot_seroprev_fitted.Rd
+++ b/man/plot_seroprev_fitted.Rd
@@ -57,7 +57,7 @@ and seropositivity on the y axis with its corresponding confidence interval.
 \examples{
 data(chagas2012)
 serodata <- prepare_serodata(chagas2012)
-seromodel_object <- run_seromodel(
+seromodel_object <- fit_seromodel(
   serodata = serodata,
   foi_model = "constant",
   iter = 1000

--- a/man/run_seromodel.Rd
+++ b/man/run_seromodel.Rd
@@ -89,6 +89,8 @@ the implementation of the model. For further details refer to
 \link{fit_seromodel}.
 }
 \description{
+Starting on v.0.1.0, this function will be DEPRECATED. Use \code{fit_seromodel}
+instead.
 This function runs the specified model for the force-of-infection \code{foi_model}
 using the data from a seroprevalence survey \code{serodata} as the input data. See
 \link{fit_seromodel} for further details.

--- a/man/run_seromodel.Rd
+++ b/man/run_seromodel.Rd
@@ -96,10 +96,12 @@ using the data from a seroprevalence survey \code{serodata} as the input data. S
 \link{fit_seromodel} for further details.
 }
 \examples{
+\dontrun{
 data(chagas2012)
 serodata <- prepare_serodata(chagas2012)
 run_seromodel(
   serodata,
   foi_model = "constant"
 )
+}
 }

--- a/man/serofoi-package.Rd
+++ b/man/serofoi-package.Rd
@@ -12,3 +12,21 @@ A DESCRIPTION OF THE PACKAGE
 Stan Development Team (NA). RStan: the R interface to Stan. R
 package version 2.26.22. https://mc-stan.org
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://trace-lac.github.io/serofoi/}
+}
+
+}
+\author{
+\strong{Maintainer}: Zulma M. Cucunubá \email{zulma.cucunuba@javeriana.edu.co} (\href{https://orcid.org/0000-0002-8165-3198}{ORCID})
+
+Authors:
+\itemize{
+  \item Nicolás T. Domínguez \email{ex-ntorres@javeriana.edu.co} (\href{https://orcid.org/0009-0002-8484-1298}{ORCID})
+  \item Ben Lambert
+  \item Pierre Nouvellet
+}
+
+}

--- a/tests/testthat/test_issue_47.R
+++ b/tests/testthat/test_issue_47.R
@@ -10,7 +10,7 @@ test_that("issue 47", {
   serodata <- readRDS(serodata_path)
 
   # Error reproduction
-  model_test <- run_seromodel(
+  model_test <- fit_seromodel(
     serodata = serodata,
     foi_model = "tv_normal",
     print_summary = FALSE

--- a/vignettes/foi_models.Rmd
+++ b/vignettes/foi_models.Rmd
@@ -50,14 +50,14 @@ The number of positive cases follows a binomial distribution, where $n$ is the n
 $$
 p(a,t) \sim binom(n(a,t), P(a,t))
 $$
-In ***serofoi***, for the constant model, the *FoI* ($\lambda$) is modelled within a Bayesian framework using a uniform prior distribution $\sim U(0,2)$. Future versions of the package may allow to choose different default distributions. This model can be implemented for the previously prepared dataset `data_test` by means of the `run_seromodel` function specifying  `run_seromodel="constant"`.
+In ***serofoi***, for the constant model, the *FoI* ($\lambda$) is modelled within a Bayesian framework using a uniform prior distribution $\sim U(0,2)$. Future versions of the package may allow to choose different default distributions. This model can be implemented for the previously prepared dataset `data_test` by means of the `fit_seromodel` function specifying  `fit_seromodel="constant"`.
 
 The object `simdata_constant` contains a minimal simulated dataset that emulates an hypothetical endemic situation where the *FoI* is constant with value 0.2 and includes data for 250 samples of individuals between 2 and 47 years old with a number of trials $n=5$. The following code shows how to implement the constant model to this simulated serosurvey:
 
 ```{r model_1, include = TRUE, echo = TRUE, results="hide", errors = FALSE, warning = FALSE, message = FALSE, fig.width=4, fig.asp=1.5, fig.align="center", out.width ="50%", fig.keep="none"}
 data("simdata_constant")
 serodata_constant <- prepare_serodata(simdata_constant)
-model_1 <- run_seromodel(
+model_1 <- fit_seromodel(
   serodata = serodata_constant,
   foi_model = "constant",
   iter = 800
@@ -102,7 +102,7 @@ The object `simdata_sw_dec` contains a minimal simulated dataset that emulates a
 ```{r model_2, include = TRUE, echo = TRUE, results="hide", errors = FALSE, warning = FALSE, message = FALSE, fig.width=4, fig.asp=1.5, fig.align="center", out.width ="50%", fig.keep="none"}
 data("simdata_sw_dec")
 serodata_sw_dec <- prepare_serodata(simdata_sw_dec)
-model_2 <- run_seromodel(
+model_2 <- fit_seromodel(
   serodata = serodata_sw_dec,
   foi_model = "tv_normal",
   iter = 1500
@@ -140,7 +140,7 @@ In order to test this model we use the minimal simulated dataset contained in th
 ```{r model_3, include = TRUE, echo = TRUE, results="hide", errors = FALSE, warning = FALSE, message = FALSE, fig.width=4, fig.asp=1.5, fig.align="center", out.width ="50%", fig.keep="none"}
 data("simdata_large_epi")
 serodata_large_epi <- prepare_serodata(simdata_large_epi)
-model_3 <- run_seromodel(
+model_3 <- fit_seromodel(
   serodata = serodata_large_epi,
   foi_model = "tv_normal_log",
   iter = 1500
@@ -191,7 +191,7 @@ Above we showed that the fast epidemic model (`tv_normal_log`) is able to identi
 Now, we would like to know whether this model actually fits this dataset better than the other available models in ***serofoi***. For this, we also implement both the endemic model (`constant`)   and the slow time-varying normal model (`tv_normal`):
 
 ```{r model_comparison, include = FALSE, echo = TRUE, results="hide", errors = FALSE, warning = FALSE, message = FALSE }
-model_1 <- run_seromodel(
+model_1 <- fit_seromodel(
   serodata = serodata_large_epi,
   foi_model = "constant",
   iter = 800
@@ -201,7 +201,7 @@ model_1_plot <- plot_seromodel(model_1,
   size_text = 6
 )
 
-model_2 <- run_seromodel(
+model_2 <- fit_seromodel(
   serodata = serodata_large_epi,
   foi_model = "tv_normal",
   iter = 1500

--- a/vignettes/serofoi.Rmd
+++ b/vignettes/serofoi.Rmd
@@ -63,7 +63,7 @@ library(serofoi)
 data(chagas2012)
 serodata_test <- prepare_serodata(chagas2012)
 # Model implementation
-model_constant <- run_seromodel(
+model_constant <- fit_seromodel(
   serodata = serodata_test,
   foi_model = "constant"
 )

--- a/vignettes/use_cases.Rmd
+++ b/vignettes/use_cases.Rmd
@@ -51,21 +51,21 @@ data("chik2015")
 chik2015p <- prepare_serodata(chik2015)
 
 # Implementation of the models
-m1_chik <- run_seromodel(
+m1_chik <- fit_seromodel(
   serodata = chik2015p,
   foi_model = "constant",
   iter = 1000,
   thin = 2
 )
 
-m2_chik <- run_seromodel(
+m2_chik <- fit_seromodel(
   serodata = chik2015p,
   foi_model = "tv_normal",
   iter = 1500,
   thin = 2
 )
 
-m3_chik <- run_seromodel(
+m3_chik <- fit_seromodel(
   serodata = chik2015p,
   foi_model = "tv_normal_log",
   iter = 1500,
@@ -112,21 +112,21 @@ data("veev2012")
 veev2012p <- prepare_serodata(veev2012)
 
 # Implementation of the models
-m1_veev <- run_seromodel(
+m1_veev <- fit_seromodel(
   serodata = veev2012p,
   foi_model = "constant",
   iter = 500,
   thin = 2
 )
 
-m2_veev <- run_seromodel(
+m2_veev <- fit_seromodel(
   serodata = veev2012p,
   foi_model = "tv_normal",
   iter = 500,
   thin = 2
 )
 
-m3_veev <- run_seromodel(
+m3_veev <- fit_seromodel(
   serodata = veev2012p,
   foi_model = "tv_normal_log",
   iter = 500,
@@ -172,12 +172,12 @@ data("chagas2012")
 chagas2012p <- prepare_serodata(chagas2012)
 
 # Implementation of the models
-m1_cha <- run_seromodel(
+m1_cha <- fit_seromodel(
   serodata = chagas2012p,
   foi_model = "constant",
   iter = 800
 )
-m2_cha <- run_seromodel(
+m2_cha <- fit_seromodel(
   serodata = chagas2012p,
   foi_model = "tv_normal",
   iter = 800


### PR DESCRIPTION
This PR:

- Deprecates `run_seromodel`
- Upgrades version tag to v.0.1.0