### PR TITLE
(i208)fix: correct time indexation in time-log-foi model

### DIFF
--- a/inst/stan/time_log_no_seroreversion.stan
+++ b/inst/stan/time_log_no_seroreversion.stan
@@ -54,7 +54,6 @@ generated quantities{
   vector[age_max] foi_expanded;
 
   for(i in 1:age_max) {
-    int time_index = age_max - i + 1;
     foi_expanded[i] = foi_vector[foi_index[i]];
   }
 

--- a/inst/stan/time_log_seroreversion.stan
+++ b/inst/stan/time_log_seroreversion.stan
@@ -62,8 +62,7 @@ generated quantities{
   vector[age_max] foi_expanded;
 
   for(i in 1:age_max) {
-    int time_index = age_max - i + 1;
-    foi_expanded[time_index] = foi_vector[foi_index[i]];
+    foi_expanded[i] = foi_vector[foi_index[i]];
   }
 
 	prob_infected_expanded = prob_infected_time_model(

--- a/inst/stan/time_no_seroreversion.stan
+++ b/inst/stan/time_no_seroreversion.stan
@@ -50,7 +50,6 @@ generated quantities{
   vector[age_max] foi_expanded;
 
   for(i in 1:age_max) {
-    int time_index = age_max - i + 1;
     foi_expanded[i] = foi_vector[foi_index[i]];
   }
 

--- a/inst/stan/time_seroreversion.stan
+++ b/inst/stan/time_seroreversion.stan
@@ -58,8 +58,7 @@ generated quantities{
   vector[age_max] foi_expanded;
 
   for(i in 1:age_max) {
-    int time_index = age_max - i + 1;
-    foi_expanded[time_index] = foi_vector[foi_index[i]];
+    foi_expanded[i] = foi_vector[foi_index[i]];
   }
 
 	prob_infected_expanded = prob_infected_time_model(


### PR DESCRIPTION
This PR addresses #208 