### PR TITLE
Add structure to `foi_index` across the package

### DIFF
--- a/R/build_stan_data.R
+++ b/R/build_stan_data.R
@@ -235,7 +235,10 @@ build_stan_data <- function(
       group_size = 1,
       model_type = model_type
     ) %>%
-    validate_foi_index()
+    validate_foi_index(
+      serosurvey = serosurvey,
+      model_type = model_type
+    )
 
     stan_data <- c(
       stan_data,

--- a/R/build_stan_data.R
+++ b/R/build_stan_data.R
@@ -63,14 +63,19 @@ sf_none <- function() {
 #'
 #' Generates a list of integers indexing together the time/age intervals
 #' for which FOI values will be estimated in [fit_seromodel].
-#' The max value in `foi_index`  correspond to the number of FOI values to
+#' The max value in `foi_index`  corresponds to the number of FOI values to
 #' be estimated when sampling.
+#' The serofoi approach to fitting serological data currently supposes that FOI
+#' is piecewise-constant across either groups of years or ages, and this
+#' function creates a Data Frame that communicates this grouping to the
+#' Stan model
 #' @inheritParams fit_seromodel
 #' @param group_size Age groups size
 #' @param model_type Type of the model. Either "age" or "time"
-#' @return Data frame with the indexes numerating each age/year (depending on
-#' the model). A single FOI value will be estimated for ages/years assigned
-#' with the same index
+#' @return A Data Frame which describes the grouping of years or ages
+#' (dependent on model) into pieces within which the FOI is assumed constant
+#' when performing model fitting. A single FOI value will be estimated for
+#' ages/years assigned with the same index
 #' @examples
 #' data(chagas2012)
 #' foi_index <- get_foi_index(chagas2012, group_size = 25, model_type = "time")

--- a/R/build_stan_data.R
+++ b/R/build_stan_data.R
@@ -234,7 +234,9 @@ build_stan_data <- function(
       serosurvey = serosurvey,
       group_size = 1,
       model_type = model_type
-    )
+    ) %>%
+    validate_foi_index()
+
     stan_data <- c(
       stan_data,
       list(foi_index = foi_index_default$foi_index)

--- a/R/build_stan_data.R
+++ b/R/build_stan_data.R
@@ -217,7 +217,7 @@ build_stan_data <- function(
     set_stan_data_defaults(
       is_log_foi = is_log_foi,
       is_seroreversion = is_seroreversion
-      )
+    )
 
   if (model_type == "constant") {
     stan_data <- c(
@@ -235,7 +235,12 @@ build_stan_data <- function(
       list(foi_index = foi_index_default$foi_index)
     )
   } else {
-    # TODO: check that foi_index is the right size
+    validate_foi_index(
+      foi_index = foi_index,
+      serosurvey = serosurvey,
+      model_type = model_type
+    )
+
     stan_data <- c(
       stan_data,
       list(foi_index = foi_index$foi_index)

--- a/R/fit_seromodel.R
+++ b/R/fit_seromodel.R
@@ -92,7 +92,7 @@ set_foi_init <- function(
 #' seromodel <- fit_seromodel(
 #' serosurvey = veev2012,
 #'   model_type = "time",
-#'   foi_index = get_foi_index(veev2012, group_size = 30)
+#'   foi_index = get_foi_index(veev2012, group_size = 30, model_type = "time")
 #' )
 #' @export
 fit_seromodel <- function(

--- a/R/validation.R
+++ b/R/validation.R
@@ -126,9 +126,17 @@ validate_foi_index <- function(
     checkmate::assert_names(names(foi_index), must.include = "year")
   }
 
-  # validate that foi_index has the right size
+  # Check that foi_index has the right properties
   stopifnot(
+    # validate that foi_index has the right size
     "foi_index must be the right size" =
-    nrow(foi_index) == max(serosurvey$age_max)
+    nrow(foi_index) == max(serosurvey$age_max),
+    # validate that foi_index contains consecutive indexes
+    "foi_index$foi_index must contain consecutive indexes" =
+    # 0 validates that indexes do not decrease for consecutive chunks
+    # 1 validates that there are not missing indexes
+    all(diff(foi_index$foi_index) %in% c(0, 1))
   )
+
+  return(foi_index)
 }

--- a/R/validation.R
+++ b/R/validation.R
@@ -107,3 +107,28 @@ validate_survey_and_foi_consistency_age_time <- function( #nolint
       "not exceed max age in survey_features."
       )
 }
+
+validate_foi_index <- function(
+  foi_index,
+  serosurvey,
+  model_type
+) {
+  # Check model_type correspond to a valid model
+  stopifnot(
+    "model_type must be either 'time' or 'age'" =
+    model_type %in% c("time", "age")
+  )
+
+  # validate that foi_index has the right columns
+  if (model_type == "age") {
+    checkmate::assert_names(names(foi_index), must.include = "age")
+  } else if (model_type == "time") {
+    checkmate::assert_names(names(foi_index), must.include = "year")
+  }
+
+  # validate that foi_index has the right size
+  stopifnot(
+    "foi_index must be the right size" =
+    nrow(foi_index) == max(serosurvey$age_max)
+  )
+}

--- a/man/fit_seromodel.Rd
+++ b/man/fit_seromodel.Rd
@@ -76,6 +76,6 @@ data(veev2012)
 seromodel <- fit_seromodel(
 serosurvey = veev2012,
   model_type = "time",
-  foi_index = get_foi_index(veev2012, group_size = 30)
+  foi_index = get_foi_index(veev2012, group_size = 30, model_type = "time")
 )
 }

--- a/man/get_foi_index.Rd
+++ b/man/get_foi_index.Rd
@@ -21,15 +21,20 @@ get_foi_index(serosurvey, group_size, model_type)
 \item{model_type}{Type of the model. Either "age" or "time"}
 }
 \value{
-Data frame with the indexes numerating each age/year (depending on
-the model). A single FOI value will be estimated for ages/years assigned
-with the same index
+A Data Frame which describes the grouping of years or ages
+(dependent on model) into pieces within which the FOI is assumed constant
+when performing model fitting. A single FOI value will be estimated for
+ages/years assigned with the same index
 }
 \description{
 Generates a list of integers indexing together the time/age intervals
 for which FOI values will be estimated in \link{fit_seromodel}.
-The max value in \code{foi_index}  correspond to the number of FOI values to
+The max value in \code{foi_index}  corresponds to the number of FOI values to
 be estimated when sampling.
+The serofoi approach to fitting serological data currently supposes that FOI
+is piecewise-constant across either groups of years or ages, and this
+function creates a Data Frame that communicates this grouping to the
+Stan model
 }
 \examples{
 data(chagas2012)

--- a/man/get_foi_index.Rd
+++ b/man/get_foi_index.Rd
@@ -4,7 +4,7 @@
 \alias{get_foi_index}
 \title{Generates force-of-infection indexes for heterogeneous age groups}
 \usage{
-get_foi_index(serosurvey, group_size)
+get_foi_index(serosurvey, group_size, model_type)
 }
 \arguments{
 \item{serosurvey}{\describe{
@@ -17,10 +17,13 @@ get_foi_index(serosurvey, group_size)
 }}
 
 \item{group_size}{Age groups size}
+
+\item{model_type}{Type of the model. Either "age" or "time"}
 }
 \value{
-Integer vector with the indexes numerating each year/age
-(depending on the model).
+Data frame with the indexes numerating each age/year (depending on
+the model). A single FOI value will be estimated for ages/years assigned
+with the same index
 }
 \description{
 Generates a list of integers indexing together the time/age intervals
@@ -30,5 +33,5 @@ be estimated when sampling.
 }
 \examples{
 data(chagas2012)
-foi_index <- get_foi_index(chagas2012, group_size = 25)
+foi_index <- get_foi_index(chagas2012, group_size = 25, model_type = "time")
 }

--- a/tests/testthat/test-fit_seromodel.R
+++ b/tests/testthat/test-fit_seromodel.R
@@ -75,7 +75,8 @@ test_that("fit_seromodel correctly estimates constant foi using default settings
     foi = foi,
     survey_features = survey_features,
     seroreversion_rate = mu
-  )
+  ) %>%
+  mutate(survey_year = 2050)
   set.seed(Sys.time())
 
   seromodel <- suppressWarnings(
@@ -105,14 +106,16 @@ test_that("fit_seromodel correctly estimates time-varying foi using default prio
     model = "time",
     foi = foi,
     survey_features = survey_features
-  )
+  ) %>%
+  mutate(survey_year = 2050)
   set.seed(Sys.time())
 
+  foi_index <- get_foi_index(serosurvey, group_size = 10, model_type = "time")
   seromodel <- suppressWarnings(
     fit_seromodel(
       serosurvey,
       model_type = "time",
-      foi_index = get_foi_index(serosurvey, group_size = 10),
+      foi_index = foi_index,
       seed = stan_seed
       )
     )
@@ -126,14 +129,16 @@ test_that("fit_seromodel correctly estimates time-varying foi using default prio
     foi = foi,
     survey_features = survey_features,
     seroreversion_rate = mu
-  )
+  ) %>%
+  mutate(survey_year = 2050)
   set.seed(Sys.time())
 
+  foi_index <- get_foi_index(serosurvey, group_size = 10, model_type = "time")
   seromodel <- suppressWarnings(
     fit_seromodel(
       serosurvey,
       model_type = "time",
-      foi_index = get_foi_index(serosurvey, group_size = 10),
+      foi_index = foi_index,
       foi_prior = sf_uniform(),
       is_seroreversion = TRUE,
       seroreversion_prior = sf_normal(mu, mu/10),
@@ -164,11 +169,12 @@ test_that("fit_seromodel correctly estimates age-varying foi", {
   )
   set.seed(Sys.time())
 
+  foi_index <- get_foi_index(serosurvey, group_size = 10, model_type = "age")
   seromodel <- suppressWarnings(
     fit_seromodel(
       serosurvey,
       model_type = "age",
-      foi_index = get_foi_index(serosurvey, group_size = 10),
+      foi_index = foi_index,
       seed = stan_seed
     )
   )
@@ -185,11 +191,12 @@ test_that("fit_seromodel correctly estimates age-varying foi", {
   )
   set.seed(Sys.time())
 
+  foi_index <- get_foi_index(serosurvey, group_size = 10, model_type = "age")
   seromodel <- suppressWarnings(
     fit_seromodel(
       serosurvey,
       model_type = "age",
-      foi_index = get_foi_index(serosurvey, group_size = 10),
+      foi_index = foi_index,
       foi_prior = sf_normal(0, 1e-4),
       is_seroreversion = TRUE,
       seroreversion_prior = sf_normal(mu, mu/10),
@@ -221,13 +228,21 @@ test_that("fit_seromodel correctly identifies outbreak using time-log-foi model"
   )
   set.seed(Sys.time())
 
+  foi_index <- data.frame(
+    year = foi$year,
+    foi_index = c(
+      rep(1, 10),
+      rep(2, outbreak_years),
+      rep(3, 10 - outbreak_years)
+    )
+  )
   seromodel <- suppressWarnings(
     fit_seromodel(
       serosurvey,
       model_type = "time",
       is_log_foi = TRUE,
       foi_prior = sf_normal(0, 1e-4),
-      foi_index = c(rep(1, 10), rep(2, outbreak_years), rep(3, 10 - outbreak_years)),
+      foi_index = foi_index,
       seed = stan_seed
     )
   )
@@ -241,16 +256,25 @@ test_that("fit_seromodel correctly identifies outbreak using time-log-foi model"
     foi = foi,
     survey_features = survey_features,
     seroreversion_rate = mu
-  )
+  ) %>%
+  mutate(survey_year = 2050)
   set.seed(Sys.time())
 
+  foi_index <- data.frame(
+    year = foi$year,
+    foi_index = c(
+      rep(1, 10),
+      rep(2, outbreak_years),
+      rep(3, 10 - outbreak_years)
+    )
+  )
   seromodel <- suppressWarnings(
     fit_seromodel(
       serosurvey,
       model_type = "time",
       is_log_foi = TRUE,
       foi_prior = sf_normal(0, 1e-4),
-      foi_index = c(rep(1, 10), rep(2, outbreak_years), rep(3, 10 - outbreak_years)),
+      foi_index = foi_index,
       is_seroreversion = TRUE,
       seroreversion_prior = sf_normal(mu, mu/10),
       seed = stan_seed

--- a/tests/testthat/test-get_foi_index.R
+++ b/tests/testthat/test-get_foi_index.R
@@ -1,0 +1,86 @@
+# Setup for testing ----
+# Sample survey features to use in test
+survey_features <- data.frame(
+  age_min = c(1, 6, 11, 16, 21),
+  age_max = c(5, 10, 15, 20, 25),
+  survey_year = 2025
+)
+
+# Test get_foi_index ----
+test_that("get_foi_index returns correct output for valid model types", {
+  # Test for model_type "age"
+  result_age <- get_foi_index(survey_features, group_size = 5, model_type = "age")
+
+  # Check if the data frame has the correct structure for "age"
+  checkmate::assert_names(
+    names(result_age),
+    must.include = c("age", "foi_index")
+  )
+  expect_equal(nrow(result_age), max(survey_features$age_max))
+
+  # Test for model_type "time"
+  result_time <- get_foi_index(survey_features, group_size = 5, model_type = "time")
+
+  # Check if the data frame has the correct structure for "time"
+  checkmate::assert_names(
+    names(result_time),
+    must.include = c("year", "foi_index")
+  )
+  expect_equal(nrow(result_time), max(survey_features$age_max))
+})
+
+test_that("get_foi_index returns an error for invalid model_type", {
+  # Test for invalid model_type
+  expect_error(
+    get_foi_index(serosurvey, model_type = "constant"),
+    regexp = "model_type must be either 'time' or 'age'"
+  )
+})
+
+test_that("get_foi_index handles different group_size correctly", {
+  # Test when group_size = 1 (edge case)
+  result_1 <- get_foi_index(
+    survey_features,
+    group_size = 1,
+    model_type = "age"
+  )
+  expected_1 <- seq(1, max(survey_features$age_max))
+
+  expect_equal(nrow(result_1), max(survey_features$age_max))
+  expect_equal(result_1$foi_index, expected_1)
+
+  # Test when group_size equals the maximum age (edge case)
+  result_max <- get_foi_index(
+    survey_features,
+    group_size = max(survey_features$age_max),
+    model_type = "time"
+  )
+  expected_max <- rep(1, 25)
+  expect_equal(nrow(result_max), max(survey_features$age_max))
+  expect_equal(result_max$foi_index, expected_max)
+
+  # Test when max age is not divisible by group_size
+  result_no_div <- get_foi_index(
+    survey_features,
+    group_size = 7,
+    model_type = "time"
+  )
+  # the remaining times are indexed in the last chunk
+  expected_no_div <- c(rep(1, 7), rep(2, 7), rep(3, 7 + 4))
+  expect_equal(nrow(result_no_div), max(survey_features$age_max))
+  expect_equal(result_no_div$foi_index, expected_no_div)
+})
+
+test_that("get_foi_index throws an error for invalid group_size", {
+  # Test for group_size > max age_max
+  expect_error(
+    get_foi_index(survey_features, group_size = 30, model_type = "age"),
+    regexp = "Assertion on 'group_size' failed"
+  )
+
+  # Test for group_size less than 1
+  expect_error(
+    get_foi_index(survey_features, group_size = 0, model_type = "age"),
+    regexp = "Assertion on 'group_size' failed"
+  )
+})

--- a/tests/testthat/test-get_foi_index.R
+++ b/tests/testthat/test-get_foi_index.R
@@ -6,6 +6,45 @@ survey_features <- data.frame(
   survey_year = 2025
 )
 
+# Test validate_foi_index ----
+test_that("validate_foi_index throws an error for non-consecutive indexes", {
+  # Test validation works for invalid sizes
+  ## shorter
+  foi_index <- data.frame(
+    age = 1:20,
+    foi_index = c(rep(1, 10), rep(2, 10))
+  )
+  expect_error(
+    serofoi:::validate_foi_index(foi_index, survey_features, model_type = "age")
+  )
+  ## longer
+  foi_index <- data.frame(
+    age = 1:30,
+    foi_index = c(rep(1, 10), rep(2, 10), rep(3, 10))
+  )
+  expect_error(
+    serofoi:::validate_foi_index(foi_index, survey_features, model_type = "age")
+  )
+
+  # Test validation works for missing indexes
+  foi_index <- data.frame(
+    age = 1:25,
+    foi_index = c(rep(1, 10), rep(3, 15))
+  )
+  expect_error(
+    serofoi:::validate_foi_index(foi_index, survey_features, model_type = "age")
+  )
+
+  # Test that validation works decreasing indexes
+  foi_index <- data.frame(
+    age = 1:25,
+    foi_index = c(rep(1, 10), rep(2, 10), rep(1, 5))
+  )
+  expect_error(
+    serofoi:::validate_foi_index(foi_index, survey_features, model_type = "age")
+  )
+})
+
 # Test get_foi_index ----
 test_that("get_foi_index returns correct output for valid model types", {
   # Test for model_type "age"

--- a/vignettes/articles/foi_models.Rmd
+++ b/vignettes/articles/foi_models.Rmd
@@ -197,11 +197,14 @@ mutate(survey_year = 2050)
 The simulated  dataset `foi_sim_sw_dec` contains information about 250 samples of individuals between 1 and 50 years old (5 samples per age) with age groups of 5 years length. The following code shows how to implement the slow time-varying normal model to this simulated serosurvey:
 
 ```{r tv_normal model, include = TRUE, echo = TRUE, results="hide", errors = FALSE, warning = FALSE, message = FALSE, fig.width=4, fig.asp=1.5, fig.align="center", out.width ="50%", fig.keep="all"}
-
+foi_index <- data.frame(
+  year = seq(2000, 2049),
+  foi_index = rep(c(1, 2, 3), c(25, 10, 15))
+)
 seromodel_time_normal <- fit_seromodel(
   serosurvey = serosurvey_sw_dec,
   model_type = "time",
-  foi_index = rep(c(1, 2, 3), c(25, 10, 15)),
+  foi_index = foi_index,
   iter = 1500
 )
 plot_seromodel(
@@ -257,11 +260,15 @@ mutate(survey_year = 2050)
 The simulated serosurvey tests 250 individuals between 1 and 50 years old by the year 2050. The implementation of the fast epidemic model can be obtained running the following lines of code:
 
 ```{r tv_normal_log model, include = TRUE, echo = TRUE, results="hide", errors = FALSE, warning = FALSE, message = FALSE, fig.width=4, fig.asp=1.5, fig.align="center", out.width ="50%", fig.keep="all"}
+foi_index <- data.frame(
+  year = seq(2000, 2049),
+  foi_index = rep(c(1, 2, 3), c(30, 5, 15))
+)
 seromodel_log_time_normal <- fit_seromodel(
   serosurvey = serosurvey_large_epi,
   model_type = "time",
   is_log_foi = TRUE,
-  foi_index = rep(c(1, 2, 3), c(30, 5, 15)),
+  foi_index = foi_index,
   iter = 2000
 )
 
@@ -296,10 +303,14 @@ plot_constant <- plot_seromodel(
   size_text = 6
 )
 
+foi_index <- data.frame(
+  year = seq(2000, 2049),
+  foi_index = rep(c(1, 2, 3), c(30, 5, 15))
+)
 seromodel_time_normal <- fit_seromodel(
   serosurvey = serosurvey_large_epi,
   model_type = "time",
-  foi_index = rep(c(1, 2, 3), c(30, 5, 15)),
+  foi_index = foi_index,
   iter = 2000
 )
 plot_time_normal <- plot_seromodel(

--- a/vignettes/articles/use_cases.Rmd
+++ b/vignettes/articles/use_cases.Rmd
@@ -48,21 +48,22 @@ seromodel_constant <- fit_seromodel(
   iter = 1000
 )
 
-
+foi_index <- get_foi_index(chik2015, group_size = 5, model_type = "time")
 seromodel_time <- fit_seromodel(
   serosurvey = chik2015,
   model_type = "time",
   foi_prior = sf_normal(0, 0.01),
-  foi_index = get_foi_index(chik2015, group_size = 5),
+  foi_index = foi_index,
   iter = 2500
 )
 
+foi_index <- get_foi_index(chik2015, group_size = 5, model_type = "time")
 seromodel_log_time <- fit_seromodel(
   serosurvey = chik2015,
   model_type = "time",
   foi_prior = sf_normal(0, 0.01),
   is_log_foi = TRUE,
-  foi_index = get_foi_index(chik2015, group_size = 5),
+  foi_index = foi_index,
   iter = 2000
 )
 
@@ -121,20 +122,22 @@ seromodel_constant <- fit_seromodel(
   iter = 1000
 )
 
+foi_index <- get_foi_index(veev2012, group_size = 5, model_type = "time")
 seromodel_time <- fit_seromodel(
   serosurvey = veev2012,
   model_type = "time",
   foi_prior = sf_normal(0, 0.1),
-  foi_index = get_foi_index(veev2012, group_size = 5),
+  foi_index = foi_index,
   iter = 2000
 )
 
+foi_index <- get_foi_index(veev2012, group_size = 5, model_type = "time")
 seromodel_log_time <- fit_seromodel(
   serosurvey = veev2012,
   model_type = "time",
   foi_prior = sf_normal(0, 0.1),
   is_log_foi = TRUE,
-  foi_index = get_foi_index(veev2012, group_size = 5),
+  foi_index = foi_index,
   iter = 2000
 )
 
@@ -191,10 +194,12 @@ seromodel_constant <- fit_seromodel(
   model_type = "constant",
   iter = 800
 )
+
+foi_index <- get_foi_index(chagas2012, group_size = 10, model_type = "time")
 seromodel_time <- fit_seromodel(
   serosurvey = chagas2012,
   model_type = "time",
-  foi_index = get_foi_index(chagas2012, group_size = 10),
+  foi_index = foi_index,
   iter = 1500
 )
 


### PR DESCRIPTION
As pointed out by @ben18785 in #200, the way in which we were indexing the FOI was ambiguous as we were just providing a vector with the indexes (see #206):
```r
...
foi_index <- rep(c(1, 2, 3), c(25, 10, 15))
seromodel_time_normal <- fit_seromodel(
  serosurvey = serosurvey,
  model_type = "time",
  foi_index = foi_index
)
```
```r
foi_index
[1] 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 2 2 2 2 2 2 2 2 2 2 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3
```
rather than an structured object to specify the age/time indexation for estimating the FOI:
```r
...
foi_index <- data.frame(
  year = seq(2000, 2049),
  foi_index = rep(c(1, 2, 3), c(25, 10, 15))
)
seromodel_time_normal <- fit_seromodel(
  serosurvey = serosurvey,
  model_type = "time",
  foi_index = foi_index
)
```
```r
glimpse(foi_index)
Rows: 50
Columns: 2
$ year      <int> 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014,…
$ foi_index <dbl> 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2,
```

Now on, users will need to specify `foi_index` as a data.frame indexing either ages or years (as shown above) rather than as an unstructured list. `get_foi_index()` may still be used for this end and its used the same as before with the caveat that the model type must be explicitly specified (e.g.):

```r
data(chagas2012)
foi_index <- get_foi_index(
  chagas2012,
  group_size = 25,
  model_type = "time"
)
glimpse(foi_index)
Rows: 79
Columns: 2
$ year      <int> 1936, 1937, 1938, 1939, 1940, 1941, 1942, 1943, 1944, 1945, 1946, 1947, 1948, 1949, 1950,…
$ foi_index <dbl> 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2,…
```

This PR also adds unit tests for `get_foi_index()`, addressing #220.

EDIT: I added additional error messages and tests validating that the indexes are consecutive, returning and error for cases like those pointed out by @ben18785 in his review. `validate_foi_index` now checks that diff(foi_index$foi_index) only contains either 0s or 1s. Any negative difference would correspond to non-consecutive indexes like 1,1,2,2,1,..., whereas any difference higher than 1 would correspond to something like 1,1,3,3,...