### PR TITLE
Add options to plot single FOI estimates and rhats

### DIFF
--- a/R/plot_seromodel.R
+++ b/R/plot_seromodel.R
@@ -427,7 +427,7 @@ plot_foi_estimates <- function(
 #'
 #' @inheritParams plot_serosurvey
 #' @inheritParams plot_summary
-#' @param xlab_constant either `"time"` or `"age"`. Specifies time axis values
+#' @param x_axis either `"time"` or `"age"`. Specifies time axis values
 #' label for constant model additional plots. Only relevant when
 #'and `seromodel@model_name == "constant"`
 #' @return ggplot object showing the r-hats of the model to be compared with the

--- a/R/plot_seromodel.R
+++ b/R/plot_seromodel.R
@@ -427,9 +427,9 @@ plot_foi_estimates <- function(
 #'
 #' @inheritParams plot_serosurvey
 #' @inheritParams plot_summary
-#' @param xlab_constant either `"time"` or `"age"`. Specifies time axis values and
+#' @param xlab_constant either `"time"` or `"age"`. Specifies time axis values
 #' label for constant model additional plots. Only relevant when
-#' `seromodel@model_name == "constant"`
+#'and `seromodel@model_name == "constant"`
 #' @return ggplot object showing the r-hats of the model to be compared with the
 #' convergence criteria (horizontal dashed line)
 #' @examples

--- a/R/plot_seromodel.R
+++ b/R/plot_seromodel.R
@@ -288,6 +288,7 @@ plot_seroprevalence_estimates <- function(
 #'
 #' @inheritParams extract_central_estimates
 #' @inheritParams fit_seromodel
+#' @inheritParams plot_rhats
 #' @param foi_df Dataframe with columns
 #' \describe{
 #'  \item{`year`/`age`}{Year/Age (depending on the model)}
@@ -429,8 +430,11 @@ plot_foi_estimates <- function(
 
 #' Plot r-hats convergence criteria for the specified model
 #'
-#' @inheritParams extract_central_estimates
 #' @inheritParams plot_serosurvey
+#' @inheritParams plot_summary
+#' @param xlab_constant either `"time"` or `"age"`. Specifies time axis values and
+#' label for constant model additional plots. Only relevant when
+#' `seromodel@model_name == "constant"`
 #' @return ggplot object showing the r-hats of the model to be compared with the
 #' convergence criteria (horizontal dashed line)
 #' @examples
@@ -535,6 +539,9 @@ plot_rhats <- function(
 #'
 #' @inheritParams summarise_seromodel
 #' @inheritParams plot_serosurvey
+#' @param plot_constant boolean specifying whether to plot single FOI estimate
+#' and its corresponding rhat value instead of showing this information in the
+#' summary. Only relevant when `seromodel@model_name == "constant"`)
 #' @return ggplot object with a summary of the specified model
 #' @examples
 #' data(veev2012)

--- a/R/plot_seromodel.R
+++ b/R/plot_seromodel.R
@@ -325,8 +325,25 @@ plot_foi_estimates <- function(
 
   model_name <- seromodel@model_name
   stopifnot(
-    "seromodel@name should start with either 'age' or 'time'" =
-    startsWith(model_name, "age") | startsWith(model_name, "time")
+    "seromodel@name should start with either 'age', 'time' or 'constant' " =
+      startsWith(model_name, "age") | startsWith(model_name, "time") |
+      startsWith(model_name, "constant")
+  )
+
+  error_msg_plot_constant <- paste0(
+    "Constant models estimate a single FOI value. To visualise it, ",
+    "specify plot_constant and x_axis accordingly."
+  )
+  error_msg_x_axis <- paste0(
+    "x_axis specification as either 'age' or 'time' when plotting ",
+    "constant FOI estimates is required to avoid ambiguity"
+  )
+  validate_plot_constant(
+    plot_constant = plot_constant,
+    x_axis = x_axis,
+    model_name = model_name,
+    error_msg_plot_constant = error_msg_plot_constant,
+    error_msg_x_axis = error_msg_x_axis
   )
 
   foi_central_estimates <- extract_central_estimates(
@@ -441,8 +458,25 @@ plot_rhats <- function(
 
   model_name <- seromodel@model_name
   stopifnot(
-    "seromodel@name should start with either 'age' or 'time'" =
-    startsWith(model_name, "age") | startsWith(model_name, "time")
+    "seromodel@name should start with either 'age', 'time' or 'constant' " =
+    startsWith(model_name, "age") | startsWith(model_name, "time") |
+    startsWith(model_name, "constant")
+  )
+
+  error_msg_plot_constant <- paste0(
+    "Constant models estimate a single FOI value. To visualise its ",
+    "rhat estimate specify plot_constant and x_axis accordingly."
+  )
+  error_msg_x_axis <- paste0(
+    "x_axis specification as either 'age' or 'time' when plotting rhat ",
+    "estimates of constant models is required to avoid ambiguity"
+  )
+  validate_plot_constant(
+    plot_constant = plot_constant,
+    x_axis = x_axis,
+    model_name = model_name,
+    error_msg_plot_constant = error_msg_plot_constant,
+    error_msg_x_axis = error_msg_x_axis
   )
 
   rhats <- bayesplot::rhat(seromodel, "foi_expanded")
@@ -525,6 +559,19 @@ plot_summary <- function(
     central_estimate_digits = central_estimate_digits,
     rhat_digits = rhat_digits
   )
+
+  if (plot_constant) {
+    if (startsWith(seromodel@model_name, "constant")) {
+      drop <- c("foi", "foi_rhat")
+      summary_list <- summary_list[!(names(summary_list) %in% drop)]
+    } else {
+      error_msg <- paste0(
+        "plot_constant is only relevant when ",
+        "`seromodel@model_name == 'constant'`"
+      )
+      stop(error_msg)
+    }
+  }
 
   summary_df <- data.frame(
     row = rev(seq_len(NCOL(t(summary_list)))),

--- a/R/plot_seromodel.R
+++ b/R/plot_seromodel.R
@@ -623,6 +623,18 @@ plot_seromodel <- function(
 ) {
   checkmate::assert_class(seromodel, "stanfit", null.ok = TRUE)
 
+  model_name <- seromodel@model_name
+  error_msg_x_axis <- paste0(
+    "x_axis specification as either 'age' or 'time' when plotting ",
+    "FOI and rhat estimates of constant models is required to avoid ambiguity"
+  )
+  validate_plot_constant(
+    plot_constant = plot_constant,
+    x_axis = x_axis,
+    model_name = model_name,
+    error_msg_x_axis = error_msg_x_axis
+  )
+
   summary_plot <- plot_summary(
     seromodel = seromodel,
     serosurvey = serosurvey,
@@ -647,29 +659,34 @@ plot_seromodel <- function(
     seroprev_plot
   )
 
-  foi_plot <- plot_foi_estimates(
-    seromodel,
-    serosurvey,
-    alpha = alpha,
-    foi_df = foi_df,
-    foi_max = foi_max,
-    size_text,
-    plot_constant = plot_constant,
-    x_axis = x_axis
-  )
+  # This condition (!p | q) is equivalent to !(p & !q)
+  # This is to preserve the default behavior for single FOI estimation for
+  # constant models
+  if (!startsWith(model_name, "constant") || plot_constant) {
+    foi_plot <- plot_foi_estimates(
+      seromodel,
+      serosurvey,
+      alpha = alpha,
+      foi_df = foi_df,
+      foi_max = foi_max,
+      size_text,
+      plot_constant = plot_constant,
+      x_axis = x_axis
+    )
 
-  rhats_plot <- plot_rhats(
-    seromodel = seromodel,
-    serosurvey = serosurvey,
-    size_text = size_text,
-    plot_constant = plot_constant,
-    x_axis = x_axis
-  )
+    rhats_plot <- plot_rhats(
+      seromodel = seromodel,
+      serosurvey = serosurvey,
+      size_text = size_text,
+      plot_constant = plot_constant,
+      x_axis = x_axis
+    )
 
-  plot_list <- c(
-    plot_list,
-    list(foi_plot, rhats_plot)
-  )
+    plot_list <- c(
+      plot_list,
+      list(foi_plot, rhats_plot)
+    )
+  }
 
   seromodel_plot <- cowplot::plot_grid(plotlist = plot_list, ncol = 1)
   return(seromodel_plot)

--- a/R/plot_seromodel.R
+++ b/R/plot_seromodel.R
@@ -331,10 +331,6 @@ plot_foi_estimates <- function(
       startsWith(model_name, "constant")
   )
 
-  error_msg_plot_constant <- paste0(
-    "Constant models estimate a single FOI value. To visualise it, ",
-    "specify plot_constant and x_axis accordingly."
-  )
   error_msg_x_axis <- paste0(
     "x_axis specification as either 'age' or 'time' when plotting ",
     "constant FOI estimates is required to avoid ambiguity"
@@ -343,7 +339,6 @@ plot_foi_estimates <- function(
     plot_constant = plot_constant,
     x_axis = x_axis,
     model_name = model_name,
-    error_msg_plot_constant = error_msg_plot_constant,
     error_msg_x_axis = error_msg_x_axis
   )
 
@@ -467,10 +462,6 @@ plot_rhats <- function(
     startsWith(model_name, "constant")
   )
 
-  error_msg_plot_constant <- paste0(
-    "Constant models estimate a single FOI value. To visualise its ",
-    "rhat estimate specify plot_constant and x_axis accordingly."
-  )
   error_msg_x_axis <- paste0(
     "x_axis specification as either 'age' or 'time' when plotting rhat ",
     "estimates of constant models is required to avoid ambiguity"
@@ -479,7 +470,6 @@ plot_rhats <- function(
     plot_constant = plot_constant,
     x_axis = x_axis,
     model_name = model_name,
-    error_msg_plot_constant = error_msg_plot_constant,
     error_msg_x_axis = error_msg_x_axis
   )
 

--- a/R/validation.R
+++ b/R/validation.R
@@ -1,3 +1,5 @@
+# TODO: Add documentation and return calls to validation functions
+
 validate_serosurvey <- function(serosurvey) {
   # Check that necessary columns are present
   col_types <- list(
@@ -139,4 +141,31 @@ validate_foi_index <- function(
   )
 
   return(foi_index)
+}
+
+validate_plot_constant <- function(
+    plot_constant,
+    x_axis,
+    model_name,
+    error_msg_plot_constant,
+    error_msg_x_axis
+) {
+  if (plot_constant) {
+    if (!startsWith(model_name, "constant")) {
+      error_msg <- paste0(
+        "plot_constant is only relevant when ",
+        "`seromodel@model_name == 'constant'`"
+      )
+      stop(error_msg)
+    }
+    if (!(x_axis %in% c("age", "time"))) {
+      stop(error_msg_x_axis)
+    }
+  } else {
+    if (startsWith(model_name, "constant")) {
+      stop(error_msg_plot_constant)
+    }
+  }
+
+  return(TRUE)
 }

--- a/R/validation.R
+++ b/R/validation.R
@@ -147,7 +147,6 @@ validate_plot_constant <- function(
     plot_constant,
     x_axis,
     model_name,
-    error_msg_plot_constant,
     error_msg_x_axis
 ) {
   if (plot_constant) {
@@ -160,10 +159,6 @@ validate_plot_constant <- function(
     }
     if (!(x_axis %in% c("age", "time"))) {
       stop(error_msg_x_axis)
-    }
-  } else {
-    if (startsWith(model_name, "constant")) {
-      stop(error_msg_plot_constant)
     }
   }
 

--- a/man/plot_foi_estimates.Rd
+++ b/man/plot_foi_estimates.Rd
@@ -44,6 +44,10 @@ with \link{fit_seromode}}
 \item{plot_constant}{boolean specifying whether to plot single FOI estimate
 and its corresponding rhat value instead of showing this information in the
 summary. Only relevant when \code{seromodel@model_name == "constant"})}
+
+\item{x_axis}{either \code{"time"} or \code{"age"}. Specifies time axis values
+label for constant model additional plots. Only relevant when
+and \code{seromodel@model_name == "constant"}}
 }
 \value{
 ggplot object with estimated force-of-infection

--- a/man/plot_foi_estimates.Rd
+++ b/man/plot_foi_estimates.Rd
@@ -10,7 +10,9 @@ plot_foi_estimates(
   alpha = 0.05,
   foi_df = NULL,
   foi_max = NULL,
-  size_text = 11
+  size_text = 11,
+  plot_constant = FALSE,
+  x_axis = NA
 )
 }
 \arguments{
@@ -38,6 +40,10 @@ with \link{fit_seromode}}
 
 \item{size_text}{Size of text for plotting (\code{base_size} in
 \link[ggplot2:ggtheme]{ggplot2})}
+
+\item{plot_constant}{boolean specifying whether to plot single FOI estimate
+and its corresponding rhat value instead of showing this information in the
+summary. Only relevant when \code{seromodel@model_name == "constant"})}
 }
 \value{
 ggplot object with estimated force-of-infection

--- a/man/plot_rhats.Rd
+++ b/man/plot_rhats.Rd
@@ -32,7 +32,7 @@ with \link{fit_seromode}}
 and its corresponding rhat value instead of showing this information in the
 summary. Only relevant when \code{seromodel@model_name == "constant"})}
 
-\item{xlab_constant}{either \code{"time"} or \code{"age"}. Specifies time axis values
+\item{x_axis}{either \code{"time"} or \code{"age"}. Specifies time axis values
 label for constant model additional plots. Only relevant when
 and \code{seromodel@model_name == "constant"}}
 }

--- a/man/plot_rhats.Rd
+++ b/man/plot_rhats.Rd
@@ -32,9 +32,9 @@ with \link{fit_seromode}}
 and its corresponding rhat value instead of showing this information in the
 summary. Only relevant when \code{seromodel@model_name == "constant"})}
 
-\item{xlab_constant}{either \code{"time"} or \code{"age"}. Specifies time axis values and
+\item{xlab_constant}{either \code{"time"} or \code{"age"}. Specifies time axis values
 label for constant model additional plots. Only relevant when
-\code{seromodel@model_name == "constant"}}
+and \code{seromodel@model_name == "constant"}}
 }
 \value{
 ggplot object showing the r-hats of the model to be compared with the

--- a/man/plot_rhats.Rd
+++ b/man/plot_rhats.Rd
@@ -4,7 +4,13 @@
 \alias{plot_rhats}
 \title{Plot r-hats convergence criteria for the specified model}
 \usage{
-plot_rhats(seromodel, serosurvey, par_name = "foi_expanded", size_text = 11)
+plot_rhats(
+  seromodel,
+  serosurvey,
+  size_text = 11,
+  plot_constant = FALSE,
+  x_axis = NA
+)
 }
 \arguments{
 \item{seromodel}{stan_fit object obtained from sampling a model
@@ -19,11 +25,16 @@ with \link{fit_seromode}}
 \item{\code{n_seropositive}}{Number of positive samples for each age group}
 }}
 
-\item{par_name}{String specifying the parameter to be extracted
-from \code{seromodel}}
-
 \item{size_text}{Size of text for plotting (\code{base_size} in
 \link[ggplot2:ggtheme]{ggplot2})}
+
+\item{plot_constant}{boolean specifying whether to plot single FOI estimate
+and its corresponding rhat value instead of showing this information in the
+summary. Only relevant when \code{seromodel@model_name == "constant"})}
+
+\item{xlab_constant}{either \code{"time"} or \code{"age"}. Specifies time axis values and
+label for constant model additional plots. Only relevant when
+\code{seromodel@model_name == "constant"}}
 }
 \value{
 ggplot object showing the r-hats of the model to be compared with the

--- a/man/plot_seromodel.Rd
+++ b/man/plot_seromodel.Rd
@@ -65,6 +65,10 @@ Otherwise, age groups are kept as originally input.}
 \item{plot_constant}{boolean specifying whether to plot single FOI estimate
 and its corresponding rhat value instead of showing this information in the
 summary. Only relevant when \code{seromodel@model_name == "constant"})}
+
+\item{x_axis}{either \code{"time"} or \code{"age"}. Specifies time axis values
+label for constant model additional plots. Only relevant when
+and \code{seromodel@model_name == "constant"}}
 }
 \value{
 seromodel summary plot

--- a/man/plot_seromodel.Rd
+++ b/man/plot_seromodel.Rd
@@ -16,7 +16,9 @@ plot_seromodel(
   central_estimate_digits = 2,
   seroreversion_digits = 2,
   rhat_digits = 2,
-  size_text = 11
+  size_text = 11,
+  plot_constant = FALSE,
+  x_axis = NA
 )
 }
 \arguments{
@@ -59,6 +61,10 @@ Otherwise, age groups are kept as originally input.}
 
 \item{size_text}{Size of text for plotting (\code{base_size} in
 \link[ggplot2:ggtheme]{ggplot2})}
+
+\item{plot_constant}{boolean specifying whether to plot single FOI estimate
+and its corresponding rhat value instead of showing this information in the
+summary. Only relevant when \code{seromodel@model_name == "constant"})}
 }
 \value{
 seromodel summary plot

--- a/man/plot_summary.Rd
+++ b/man/plot_summary.Rd
@@ -10,7 +10,8 @@ plot_summary(
   loo_estimate_digits = 1,
   central_estimate_digits = 2,
   rhat_digits = 2,
-  size_text = 11
+  size_text = 11,
+  plot_constant = FALSE
 )
 }
 \arguments{
@@ -34,6 +35,10 @@ with \link{fit_seromode}}
 
 \item{size_text}{Size of text for plotting (\code{base_size} in
 \link[ggplot2:ggtheme]{ggplot2})}
+
+\item{plot_constant}{boolean specifying whether to plot single FOI estimate
+and its corresponding rhat value instead of showing this information in the
+summary. Only relevant when \code{seromodel@model_name == "constant"})}
 }
 \value{
 ggplot object with a summary of the specified model

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -163,3 +163,46 @@ test_that("validate_survey_and_foi_consistency_age_time throws error if max age 
     "maximum age implicit in foi_df should not exceed max age in survey_features"
   )
 })
+
+# Test for validate_plot_constant ----
+test_that("validate_plot_constant works as expected", {
+  # Valid cases
+  expect_true(
+    validate_plot_constant(
+      plot_constant = TRUE,
+      x_axis = "age",
+      model_name = "constant_model",
+      error_msg_x_axis = "x_axis must be either 'age' or 'time'."
+    )
+  )
+
+  expect_true(
+    validate_plot_constant(
+      plot_constant = FALSE,
+      x_axis = "time",
+      model_name = "time_varying_model",
+      error_msg_x_axis = "x_axis must be either 'age' or 'time'."
+    )
+  )
+
+  # Invalid cases
+  expect_error(
+    validate_plot_constant(
+      plot_constant = TRUE,
+      x_axis = "invalid_axis",
+      model_name = "constant_model",
+      error_msg_x_axis = "x_axis must be either 'age' or 'time'."
+    ),
+    "x_axis must be either 'age' or 'time'."
+  )
+
+  expect_error(
+    validate_plot_constant(
+      plot_constant = TRUE,
+      x_axis = "age",
+      model_name = "time_varying_model",
+      error_msg_x_axis = "x_axis must be either 'age' or 'time'."
+    ),
+    "plot_constant is only relevant when `seromodel@model_name == 'constant'`"
+  )
+})


### PR DESCRIPTION
This PR introduces parameters `plot_constant` and `x_axis` to the visualisation functions of the package. These enable the option to plot constant FOI estimates and their corresponding r-hat values, avoiding ambiguity in the specification of the x-axis by means of `x_axis = "time"` or `x_axis = "age"`.

Currently, `plot_seromodel()` behaves differently for constant models. The single FOI estimate and its corresponging r-hat value are displayed in the summary generated by means of `plot_summary()`, e.g.
```r
data("chagas2012")
seromodel <- fit_seromodel(chagas2012)
plot_seromodel(seromodel, chagas2012, bin_serosurvey = TRUE)
```
![image](https://github.com/user-attachments/assets/a86233ee-eaee-424f-baf9-ffca0f111af1)

This is preserved as the default behavior, as we would have to choose arbitrarily to plot either with respect to time or age otherwise. Now, if `plot_model = TRUE` and a constant model is provided, the x-axis can be specified to be either age or time by means of `x_axis`, e.g.
```r
plot_seromodel(
  seromodel,
  serosurvey,
  plot_constant = TRUE,
  x_axis = "time",
  bin_serosurvey = TRUE
  )
```
![image](https://github.com/user-attachments/assets/e711930f-3640-4811-b59c-5a70f0f8cc4f)

Exceptions for other possible scenarios are handled by the new validation function `validate_plot_constant()`. This function stops the process whenever `plot_constant = TRUE` and a non-constant model is provided, or if `x_axis` is not set up properly when intending to plot constant models. Informative error messages are provided in both cases.