### PR TITLE
Implement linter v3.2.0 corrections

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -2,7 +2,6 @@ linters: all_linters(
     packages = c("lintr", "etdev"),
     object_name_linter = NULL,
     implicit_integer_linter = NULL,
-    extraction_operator_linter = NULL,
     todo_comment_linter = NULL,
     library_call_linter = NULL,
     undesirable_function_linter(

--- a/R/build_stan_data.R
+++ b/R/build_stan_data.R
@@ -11,7 +11,9 @@ sf_normal <- function(mean = 0, sd = 1) {
   if (mean < 0 || sd <= 0) {
     stop(
       "Normal distribution only accepts",
-      " `mean>=0` and `sd>0` for mean and standard deviation")
+      " `mean>=0` and `sd>0` for mean and standard deviation",
+      call. = FALSE
+    )
   }
 
   return(list(mean = mean, sd = sd, name = "normal"))
@@ -30,7 +32,8 @@ sf_uniform <- function(min = 0, max = 10) {
   if (min < 0 || (min >= max)) {
     stop(
       "Uniform distribution only accepts",
-      " 0<=min<max"
+      " 0<=min<max",
+      call. = FALSE
     )
   }
 
@@ -46,11 +49,11 @@ sf_uniform <- function(min = 0, max = 10) {
 #' my_prior <- sf_cauchy()
 #' @export
 sf_cauchy <- function(location = 0, scale = 1) {
-  # Restricting normal inputs to be non-negative
-  if (location < 0 || scale < 0) {
+  if (location < 0 || scale < 0) { # Restricting inputs to be non-negative
     stop(
       "Cauchy distribution only accepts",
-      " `location>=0` and `scale>=0` for median and median absolute deviation")
+      " `location>=0` and `scale>=0` for median and median absolute deviation",
+      call. = FALSE)
   }
 
   return(list(location = location, scale = scale, name = "cauchy"))

--- a/R/build_stan_data.R
+++ b/R/build_stan_data.R
@@ -285,16 +285,27 @@ build_stan_data <- function(
 
   if (is_seroreversion) {
     if (seroreversion_prior$name == "none") {
-      stop("seroreversion_prior not specified")
-    } else if (seroreversion_prior$name == "uniform") {
-      stan_data$seroreversion_prior_index <- prior_index[["uniform"]]
-      stan_data$seroreversion_min <- seroreversion_prior$min
-      stan_data$seroreversion_max <- seroreversion_prior$max
-    } else if (seroreversion_prior$name == "normal") {
-      stan_data$seroreversion_prior_index <- prior_index[["normal"]]
-      stan_data$seroreversion_mean <- seroreversion_prior$mean
-      stan_data$seroreversion_sd <- seroreversion_prior$sd
+      stop("seroreversion_prior not specified", call. = FALSE)
     }
+
+    stan_data$seroreversion_prior_index <- switch(
+      seroreversion_prior$name,
+      uniform = prior_index[["uniform"]],
+      normal = prior_index[["normal"]],
+      stop("Invalid seroreversion_prior name", call. = FALSE) # Default case
+    )
+
+    switch(
+      seroreversion_prior$name,
+      uniform = {
+        stan_data$seroreversion_min <- seroreversion_prior$min
+        stan_data$seroreversion_max <- seroreversion_prior$max
+      },
+      normal = {
+        stan_data$seroreversion_mean <- seroreversion_prior$mean
+        stan_data$seroreversion_sd <- seroreversion_prior$sd
+      }
+    )
   }
 
   return(stan_data)

--- a/R/build_stan_data.R
+++ b/R/build_stan_data.R
@@ -64,7 +64,7 @@ sf_cauchy <- function(location = 0, scale = 1) {
 #' @return List with the name of the empty distribution
 #' @export
 sf_none <- function() {
-  return(list(name = "none"))
+  list(name = "none")
 }
 
 #' Generates force-of-infection indexes for heterogeneous age groups
@@ -138,7 +138,7 @@ get_foi_index <- function(
     )
   }
 
-  return(foi_index)
+  foi_index
 }
 
 #' Set stan data defaults for sampling

--- a/R/fit_seromodel.R
+++ b/R/fit_seromodel.R
@@ -13,7 +13,7 @@ add_age_group_to_serosurvey <- function(serosurvey) {
       age_group = floor((.data$age_min + .data$age_max) / 2)
     )
   }
-  return(serosurvey)
+  serosurvey
 }
 
 #' Sets initialization function for sampling
@@ -56,7 +56,7 @@ set_foi_init <- function(
   checkmate::assert_class(foi_init, "function")
   checkmate::assert_double(unlist(foi_init()[[1]]), len = max(foi_index))
 
-  return(foi_init)
+  foi_init
 }
 
 #' Runs specified stan model for the force-of-infection

--- a/R/plot_seromodel.R
+++ b/R/plot_seromodel.R
@@ -572,16 +572,15 @@ plot_summary <- function(
   )
 
   if (plot_constant) {
-    if (startsWith(seromodel@model_name, "constant")) {
-      drop <- c("foi", "foi_rhat")
-      summary_list <- summary_list[!(names(summary_list) %in% drop)]
-    } else {
+    if (!startsWith(seromodel@model_name, "constant")) {
       error_msg <- paste0(
         "plot_constant is only relevant when ",
         "`seromodel@model_name == 'constant'`"
       )
       stop(error_msg, call. = FALSE)
     }
+    drop_list <- c("foi", "foi_rhat")
+    summary_list <- summary_list[!(names(summary_list) %in% drop_list)]
   }
 
   summary_df <- data.frame(

--- a/R/plot_seromodel.R
+++ b/R/plot_seromodel.R
@@ -82,7 +82,7 @@ get_age_intervals <- function(serosurvey, step) {
     warn_msg <- paste0(
       warn_msg, "[", limits_low[length(limits_low)], ",", age_max, "]"
     )
-    warning(warn_msg)
+    warning(warn_msg, call. = FALSE)
   }
 
   # prepare breaks
@@ -578,7 +578,7 @@ plot_summary <- function(
         "plot_constant is only relevant when ",
         "`seromodel@model_name == 'constant'`"
       )
-      stop(error_msg)
+      stop(error_msg, call. = FALSE)
     }
   }
 

--- a/R/plot_seromodel.R
+++ b/R/plot_seromodel.R
@@ -44,7 +44,7 @@ prepare_serosurvey_for_plot <- function(
       )
     )) |>
     dplyr::ungroup() |>
-    tidyr::unnest_wider(.data$binconf) |>
+    tidyr::unnest_wider(!!dplyr::sym("binconf")) |>
     dplyr::arrange(.data$age_group) |>
     dplyr::relocate(!!dplyr::sym("age_group"))
 

--- a/R/plot_seromodel.R
+++ b/R/plot_seromodel.R
@@ -264,13 +264,14 @@ plot_seroprev_estimates <- function(
     age = 0
   ) |>
   rbind(
-    extract_central_estimates(
-      seromodel = seromodel,
-      serosurvey = serosurvey,
-      alpha = alpha,
-      par_name = "prob_infected_expanded"
-  ) |>
-    dplyr::mutate(age = seq(1, max(serosurvey$age_max)))
+    dplyr::mutate(
+      extract_central_estimates(
+        seromodel = seromodel,
+        serosurvey = serosurvey,
+        alpha = alpha,
+        par_name = "prob_infected_expanded"
+      ),
+      age = seq(1, max(serosurvey$age_max)))
   )
 
   seroprev_plot <- plot_serosurvey(

--- a/R/plot_seromodel.R
+++ b/R/plot_seromodel.R
@@ -30,7 +30,8 @@ prepare_serosurvey_for_plot <- function(
       conf.level = 1 - alpha
     )$conf.int
     names(ci) <- c("seroprev_lower", "seroprev_upper")
-    return(ci)
+
+    ci
   }
 
   serosurvey <- serosurvey |>
@@ -103,7 +104,7 @@ get_age_intervals <- function(serosurvey, step) {
       labels = survey_features$group
     )
 
-  return(serosurvey)
+  serosurvey
 }
 
 #' Plots seroprevalence from the given serosurvey

--- a/R/simulate_serosurvey.R
+++ b/R/simulate_serosurvey.R
@@ -794,7 +794,7 @@ simulate_serosurvey <- function(
 
   # don't advertise time-age in case people think this is something else
   if (!model %in% c("age", "time", "age-time", "time-age"))
-    stop("model must be one of 'age', 'time', or 'age-time'.")
+    stop("model must be one of 'age', 'time', or 'age-time'.", call. = FALSE)
 
   if (model == "time") {
     serosurvey <- simulate_serosurvey_time(

--- a/R/simulate_serosurvey.R
+++ b/R/simulate_serosurvey.R
@@ -97,12 +97,12 @@ prob_seroprev_time_by_age <- function(
     seroreversion_rate = seroreversion_rate
   )
 
-  df <- data.frame(
+  seroprev_df <- data.frame(
     age = seq_along(years),
     seropositivity = probabilities
   )
 
-  return(df)
+  seroprev_df
 }
 
 
@@ -132,12 +132,12 @@ prob_seroprev_age_by_age <- function(
     seroreversion_rate = seroreversion_rate
   )
 
-  df <- data.frame(
+  seroprev_df <- data.frame(
     age = ages,
     seropositivity = probabilities
   )
 
-  return(df)
+  seroprev_df
 }
 
 #' Generate probabilities of seropositivity by age based on an age-and-time
@@ -194,12 +194,12 @@ prob_seroprev_age_time_by_age <- function(
   }
   probabilities_oldest_age_last <- rev(probabilities)
 
-  df <- data.frame(
+  seroprev_df <- data.frame(
     age = ages,
     seropositivity = probabilities_oldest_age_last
   )
 
-  return(df)
+  seroprev_df
 }
 
 #' Generate probabilities of seropositivity by age based on model choice.
@@ -242,12 +242,12 @@ prob_seroprev_by_age <- function(
     probability_function <- prob_seroprev_age_time_by_age
   }
 
-  df <- probability_function(
+  seroprev_df <- probability_function(
     foi = foi,
     seroreversion_rate = seroreversion_rate
   )
 
-  return(df)
+  return(seroprev_df)
 }
 
 #' Generate probabilities of seropositivity by age based on a general FOI model.
@@ -331,7 +331,7 @@ prob_seroprev_gen_by_age <- function(
       }
       k <- k + 1
     }
-    return(A)
+    A
   }
 
   probabilities <- vector(length = max_age)
@@ -341,12 +341,12 @@ prob_seroprev_gen_by_age <- function(
     probabilities[i] <- calculate_seroprev_fun(Y)
   }
 
-  df <- data.frame(
+  seroprev_df <- data.frame(
     age = 1:max_age,
     seropositivity = probabilities
   )
 
-  return(df)
+  seroprev_df
 }
 
 
@@ -370,7 +370,8 @@ add_age_bins <- function(survey_features) {
     intervals[i] <- paste0("[", age_min, ",", age_max, "]")
   }
   survey_features <- dplyr::mutate(survey_features, group = intervals)
-  return(survey_features)
+
+  survey_features
 }
 
 #' Create a survey dataframe with per individual age information.
@@ -391,7 +392,7 @@ survey_by_individual_age <- function(survey_features, age_df) {
     ) |>
     dplyr::rename(overall_sample_size = "n_sample")
 
-  return(overall_sample_size_df)
+  overall_sample_size_df
 }
 
 #' Generate random sample sizes using multinomial sampling.
@@ -411,7 +412,8 @@ multinomial_sampling_group <- function(n_sample, n_ages) {
   sample_size_by_age <- as.vector(
     stats::rmultinom(1, n_sample, prob = probs)
   )
-  return(sample_size_by_age)
+
+  sample_size_by_age
 }
 
 #' Generate random sample sizes for each age group.
@@ -449,7 +451,8 @@ generate_random_sample_sizes <- function(survey_df_long) {
       df_new <- dplyr::bind_rows(df_new, df_tmp)
     }
   }
-  return(df_new)
+
+  df_new
 }
 
 #' Generate random sample sizes for each individual age based on survey
@@ -497,7 +500,7 @@ sample_size_by_individual_age <- function(survey_features) {
 
   df_new <- generate_random_sample_sizes(survey_features_all_ages)
 
-  return(df_new)
+  df_new
 }
 
 #' Generate seropositivity counts by bin given the probability and sample size
@@ -538,7 +541,7 @@ get_seroprev_counts_by_bin <- function(
     by = c("age_min", "age_max", "n_sample")
   )
 
-  return(grouped_df)
+  grouped_df
 }
 
 #' Simulate serosurvey data based on a time-varying FOI model.
@@ -899,5 +902,5 @@ simulate_serosurvey_general <- function( #nolint
     survey_features
   )
 
-  return(grouped_df)
+  grouped_df
 }

--- a/R/simulate_serosurvey.R
+++ b/R/simulate_serosurvey.R
@@ -158,14 +158,13 @@ prob_seroprev_age_time_by_age <- function(
   seroreversion_rate
 ) {
 
-  foi_matrix <- as.matrix(
-    tidyr::pivot_wider(
-      foi,
-      values_from = foi,
-      names_from = dplyr::all_of("year")
+  foi_matrix <- tidyr::pivot_wider(
+    foi,
+    values_from = foi,
+    names_from = dplyr::all_of("year")
     ) |>
-    tibble::column_to_rownames("age")
-  )
+    tibble::column_to_rownames("age") |>
+    as.matrix()
 
   years <- unique(foi$year)
   n_years <- length(years)

--- a/R/validation.R
+++ b/R/validation.R
@@ -34,11 +34,12 @@ validate_serosurvey <- function(serosurvey) {
   if (length(error_messages) > 0) {
     stop(
       "The following columns in `serosurvey` have wrong types:\n",
-      toString(error_messages)
+      toString(error_messages),
+      call. = FALSE
     )
   }
 
-  return(serosurvey)
+  serosurvey
 }
 
 #' Check min and max age consistency for validation purposes
@@ -68,7 +69,8 @@ validate_survey_features <- function(survey_features) {
       ) {
     stop(
       "survey_features must be a dataframe with columns ",
-      "'age_min', 'age_max', and 'n_sample'."
+      "'age_min', 'age_max', and 'n_sample'.",
+      call. = FALSE
       )
   }
 
@@ -78,7 +80,8 @@ validate_survey_features <- function(survey_features) {
   if (!is_age_ok)
     stop(
       "Age bins in a survey are inclusive of both bounds, ",
-      "so the age_max of one bin cannot equal the age_min of another."
+      "so the age_max of one bin cannot equal the age_min of another.",
+      call. = FALSE
       )
 }
 
@@ -100,7 +103,7 @@ validate_foi_df <- function(foi_df, cnames_additional) {
         )
     }
     message_beginning <- "foi must be a dataframe with columns foi"
-    stop(glue::glue("{message_beginning}", "{message_end}"))
+    stop(glue::glue("{message_beginning}", "{message_end}"), call. = FALSE)
   }
 }
 
@@ -110,7 +113,9 @@ validate_foi_df <- function(foi_df, cnames_additional) {
 #' @keywords internal
 validate_seroreversion_rate <- function(seroreversion_rate) {
   if (!is.numeric(seroreversion_rate) || seroreversion_rate < 0) {
-    stop("seroreversion_rate must be a non-negative numeric value.")
+    stop(
+      "seroreversion_rate must be a non-negative numeric value.",
+      call. = FALSE)
   }
 }
 
@@ -127,7 +132,8 @@ validate_simulation_age <- function(
   if (max_age_foi_df > max(survey_features$age_max))
     stop(
       "maximum age implicit in foi_df should ",
-      "not exceed max age in survey_features."
+      "not exceed max age in survey_features.",
+      call. = FALSE
       )
 }
 
@@ -144,7 +150,8 @@ validate_simulation_age_time <- function(
   if (max_age_foi_df > max(survey_features$age_max))
     stop(
       "maximum age implicit in foi_df should ",
-      "not exceed max age in survey_features."
+      "not exceed max age in survey_features.",
+      call. = FALSE
       )
 }
 

--- a/R/validation.R
+++ b/R/validation.R
@@ -54,7 +54,8 @@ check_age_constraints <- function(df) {
       }
     }
   }
-  return(TRUE)
+
+  TRUE
 }
 
 #' Helper function to validate serosurvey features for simulation
@@ -189,7 +190,7 @@ validate_foi_index <- function(
     all(diff(foi_index$foi_index) %in% c(0, 1))
   )
 
-  return(foi_index)
+  foi_index
 }
 
 #' Helper function to validate whether the current plot corresponds
@@ -209,12 +210,12 @@ validate_plot_constant <- function(
         "plot_constant is only relevant when ",
         "`seromodel@model_name == 'constant'`"
       )
-      stop(error_msg)
+      stop(error_msg, call. = FALSE)
     }
     if (!(x_axis %in% c("age", "time"))) {
-      stop(error_msg_x_axis)
+      stop(error_msg_x_axis, call. = FALSE)
     }
   }
 
-  return(TRUE)
+  TRUE
 }

--- a/R/validation.R
+++ b/R/validation.R
@@ -187,7 +187,7 @@ validate_foi_index <- function(
     "foi_index$foi_index must contain consecutive indexes" =
     # 0 validates that indexes do not decrease for consecutive chunks
     # 1 validates that there are not missing indexes
-    all(diff(foi_index$foi_index) %in% c(0, 1))
+    diff(foi_index$foi_index) %in% c(0, 1)
   )
 
   foi_index

--- a/vignettes/articles/simulating_serosurveys.Rmd
+++ b/vignettes/articles/simulating_serosurveys.Rmd
@@ -52,7 +52,8 @@ serosurvey_constant <- simulate_serosurvey(
   model = "age",
   foi = foi_constant,
   survey_features = survey_features
-)
+) |>
+  mutate(model_type = "constant FOI")
 
 glimpse(serosurvey_constant)
 ```
@@ -95,7 +96,8 @@ serosurvey_age_dep <- simulate_serosurvey(
   model = "age",
   foi = foi_age_varying,
   survey_features = survey_features
-)
+) |>
+    mutate(model_type = "age-dependent FOI")
 
 ```
 
@@ -103,27 +105,29 @@ Below, we see that the FOI for the age-dependent FOI pathogen increases rapidly 
 
 ```{r, fig.align="center"}
 # combine with constant FOI survey
-serosurvey_combined <- rbind(
-  serosurvey_constant |>
-    mutate(model_type = "constant FOI") |>
-  left_join(
-    prob_seroprev_by_age(
+prob_seroprev_constant <- prob_seroprev_by_age(
       model = "age",
       foi = foi_constant,
       seroreversion_rate = 0
       ) |>
-      rename(age_min = age),
+      rename(age_min = age)
+
+prob_seroprev_age <- prob_seroprev_by_age(
+      model = "age",
+      foi = foi_age_varying,
+      seroreversion_rate = 0
+      ) |>
+  rename(age_min = age)
+
+serosurvey_combined <- rbind(
+  left_join(
+    serosurvey_constant,
+    prob_seroprev_constant,
     by = "age_min"
     ),
-  serosurvey_age_dep |>
-    mutate(model_type = "age-dependent FOI") |>
-      left_join(
-          prob_seroprev_by_age(
-          model = "age",
-          foi = foi_age_varying,
-          seroreversion_rate = 0
-      ) |>
-        rename(age_min = age),
+  left_join(
+    serosurvey_age_dep,
+    prob_seroprev_age,
       by = "age_min"
       )
   )  |>
@@ -265,7 +269,8 @@ serosurvey <- simulate_serosurvey(
   model = "age-time",
   foi = foi_age_time,
   survey_features = survey_features
-)
+) |>
+    mutate(model_type = "non-seroreverting")
 ```
 
 ```{r, fig.align="center", fig.alt="Plot serosurvey obtained simulating from time- and age-dependent FOI"}
@@ -293,34 +298,37 @@ serosurvey_serorevert <- simulate_serosurvey(
   foi = foi_age_time,
   survey_features = survey_features,
   seroreversion_rate = 0.01
-)
+) |>
+    mutate(model_type = "seroreverting")
 ```
 
 ```{r, fig.align="center", fig.alt="Plot comparing serosurveys with and without seroreversion"}
 # combine with constant FOI survey
+prob_seroprev_no_serorev <- prob_seroprev_by_age(
+  model = "age-time",
+  foi = foi_age_time,
+  seroreversion_rate = 0
+  ) |>
+  rename(age_min = age)
+
+prob_seroprev_serorev <- prob_seroprev_by_age(
+  model = "age-time",
+  foi = foi_age_time,
+  seroreversion_rate = 0.01
+  ) |>
+  rename(age_min = age)
+
 serosurvey_combined <- rbind(
-  serosurvey |>
-    mutate(model_type = "non-seroreverting") |>
   left_join(
-    prob_seroprev_by_age(
-      model = "age-time",
-      foi = foi_age_time,
-      seroreversion_rate = 0
-      ) |>
-      rename(age_min = age),
+    serosurvey,
+    prob_seroprev_no_serorev,
     by = "age_min"
     ),
-  serosurvey_serorevert |>
-    mutate(model_type = "seroreverting") |>
-      left_join(
-          prob_seroprev_by_age(
-          model = "age-time",
-          foi = foi_age_time,
-          seroreversion_rate = 0.01
-      ) |>
-        rename(age_min = age),
-      by = "age_min"
-      )
+  left_join(
+    serosurvey_serorevert,
+    prob_seroprev_serorev,
+    by = "age_min"
+    )
   ) |>
   mutate(model_type = as.factor(model_type))
 


### PR DESCRIPTION
The last linter update (v3.2.0) seems to be suggesting new style conventions (see for instance #287):
![image](https://github.com/user-attachments/assets/40115fc2-6b1f-443f-aa4b-98b60dc2a139)

This PR addresses all of them.